### PR TITLE
feat: 新增 fire_regions 火区面图层并支持双轨火情渲染

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@
 已实现可视化叠加：
 
 - 火情热点图层（`fire_hotspots`）：地图显示火点标记、地面影响圈、强度颜色。
+- 火区面图层（`fire_regions`）：按热点聚类与扩散速度估算连续火区半径。
 - 任务图层（`mission_targets`）：显示 UAV 到任务目标的虚线。
 - 右上角状态摘要：`fire`、`max_fire`、`mission`、`basemap`。
 
@@ -201,6 +202,7 @@
 - 默认：`http://127.0.0.1:8899/cesium`
 - 强制在线底图：`http://127.0.0.1:8899/cesium?basemap=osm`
 - 强制网格底图：`http://127.0.0.1:8899/cesium?basemap=grid`
+- 关闭火区面图层：`http://127.0.0.1:8899/cesium?fire_region=off`
 
 ## 备注
 

--- a/scripts/fire_region_model.py
+++ b/scripts/fire_region_model.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import math
+from typing import Dict, List, Tuple
+
+
+def _clamp(v: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, v))
+
+
+def _distance_m(a_lat: float, a_lon: float, b_lat: float, b_lon: float) -> float:
+    dlat = (a_lat - b_lat) * 111000.0
+    mid_lat = (a_lat + b_lat) * 0.5
+    dlon = (a_lon - b_lon) * 111000.0 * math.cos(math.radians(mid_lat))
+    return math.hypot(dlat, dlon)
+
+
+def _single_radius_m(hs: Dict[str, object], age_s: float) -> float:
+    intensity = float(hs.get("intensity", 0.0))
+    spread = float(hs.get("spread_mps", 0.0))
+    base = 80.0 + intensity * 180.0
+    grow = spread * max(0.0, age_s)
+    return _clamp(base + grow, 80.0, 2500.0)
+
+
+def build_fire_regions(
+    hotspots: List[Dict[str, object]],
+    now_ms: int,
+    first_seen_ms: Dict[str, int],
+    merge_distance_m: float = 320.0,
+) -> List[Dict[str, object]]:
+    if not hotspots:
+        return []
+
+    n = len(hotspots)
+    parent = list(range(n))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: int, b: int) -> None:
+        pa = find(a)
+        pb = find(b)
+        if pa != pb:
+            parent[pb] = pa
+
+    for i in range(n):
+        ai = hotspots[i]
+        alat = float(ai["position"][0])
+        alon = float(ai["position"][1])
+        for j in range(i + 1, n):
+            bj = hotspots[j]
+            blat = float(bj["position"][0])
+            blon = float(bj["position"][1])
+            if _distance_m(alat, alon, blat, blon) <= merge_distance_m:
+                union(i, j)
+
+    groups: Dict[int, List[int]] = {}
+    for i in range(n):
+        groups.setdefault(find(i), []).append(i)
+
+    regions: List[Dict[str, object]] = []
+    for root, idxs in groups.items():
+        members = [hotspots[i] for i in idxs]
+        weighted_sum = 0.0
+        c_lat = 0.0
+        c_lon = 0.0
+        c_alt = 0.0
+        max_intensity = 0.0
+        total_spread = 0.0
+        member_ids: List[str] = []
+
+        for hs in members:
+            hid = str(hs.get("id", ""))
+            member_ids.append(hid)
+            w = max(0.1, float(hs.get("intensity", 0.0)))
+            c_lat += float(hs["position"][0]) * w
+            c_lon += float(hs["position"][1]) * w
+            c_alt += float(hs["position"][2]) * w
+            weighted_sum += w
+            max_intensity = max(max_intensity, float(hs.get("intensity", 0.0)))
+            total_spread += float(hs.get("spread_mps", 0.0))
+
+        c_lat /= weighted_sum
+        c_lon /= weighted_sum
+        c_alt /= weighted_sum
+
+        max_radius = 0.0
+        for hs in members:
+            hid = str(hs.get("id", ""))
+            if hid and hid not in first_seen_ms:
+                first_seen_ms[hid] = now_ms
+            seen_ms = first_seen_ms.get(hid, now_ms)
+            age_s = max(0.0, (now_ms - seen_ms) / 1000.0)
+            local_r = _single_radius_m(hs, age_s)
+            dist = _distance_m(c_lat, c_lon, float(hs["position"][0]), float(hs["position"][1]))
+            max_radius = max(max_radius, dist + local_r)
+
+        avg_spread = total_spread / max(1, len(members))
+        region_id = f"region_{root}"
+        regions.append(
+            {
+                "id": region_id,
+                "center": [c_lat, c_lon, c_alt],
+                "radius_m": _clamp(max_radius, 120.0, 3200.0),
+                "intensity": _clamp(max_intensity, 0.0, 1.0),
+                "spread_mps": max(0.0, avg_spread),
+                "member_count": len(members),
+                "member_ids": member_ids,
+            }
+        )
+
+    regions.sort(key=lambda x: float(x["radius_m"]), reverse=True)
+    return regions

--- a/scripts/ros2_visualization_server.py
+++ b/scripts/ros2_visualization_server.py
@@ -9,6 +9,8 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from glob import glob
 
+from fire_region_model import build_fire_regions
+
 ros_lib_paths = [
     "/opt/ros/humble/lib",
     "/opt/ros/humble/local/lib",
@@ -54,11 +56,13 @@ except ModuleNotFoundError:
 class SwarmStateCache:
     def __init__(self) -> None:
         self._lock = threading.Lock()
+        self._fire_first_seen_ms: dict[str, int] = {}
         self._payload = {
             "timestamp": 0,
             "uavs": [],
             "links": [],
             "fire_hotspots": [],
+            "fire_regions": [],
             "mission_targets": [],
         }
 
@@ -90,6 +94,7 @@ class SwarmStateCache:
             "uavs": uavs,
             "links": links,
             "fire_hotspots": self._payload.get("fire_hotspots", []),
+            "fire_regions": self._payload.get("fire_regions", []),
             "mission_targets": self._payload.get("mission_targets", []),
         }
 
@@ -97,6 +102,7 @@ class SwarmStateCache:
             self._payload = payload
 
     def update_fire(self, msg: FireState) -> None:
+        stamp_ms = int(msg.stamp.sec * 1000 + msg.stamp.nanosec / 1_000_000)
         fire = [
             {
                 "id": hs.id,
@@ -106,8 +112,10 @@ class SwarmStateCache:
             }
             for hs in msg.hotspots
         ]
+        regions = build_fire_regions(fire, stamp_ms, self._fire_first_seen_ms)
         with self._lock:
             self._payload["fire_hotspots"] = fire
+            self._payload["fire_regions"] = regions
 
     def update_mission(self, msg: MissionPlan) -> None:
         targets = [

--- a/tests/test_fire_region_model.py
+++ b/tests/test_fire_region_model.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from fire_region_model import build_fire_regions  # noqa: E402
+
+
+def assert_true(cond: bool, msg: str) -> None:
+    if not cond:
+        raise AssertionError(msg)
+
+
+def sample_hotspots() -> list[dict]:
+    return [
+        {
+            "id": "hotspot_a",
+            "position": [39.9042, 116.4074, 100.0],
+            "intensity": 0.9,
+            "spread_mps": 0.8,
+        },
+        {
+            "id": "hotspot_b",
+            "position": [39.9045, 116.4077, 100.0],
+            "intensity": 0.7,
+            "spread_mps": 0.6,
+        },
+        {
+            "id": "hotspot_far",
+            "position": [39.9120, 116.4200, 100.0],
+            "intensity": 0.8,
+            "spread_mps": 0.4,
+        },
+    ]
+
+
+def test_cluster_and_growth() -> None:
+    first_seen: dict[str, int] = {}
+    hs = sample_hotspots()
+    regions_t0 = build_fire_regions(hs, now_ms=1_000_000, first_seen_ms=first_seen, merge_distance_m=320.0)
+    assert_true(len(regions_t0) == 2, "应形成两个火区（近处聚合 + 远处单独）")
+    max_r0 = max(float(r["radius_m"]) for r in regions_t0)
+
+    regions_t1 = build_fire_regions(hs, now_ms=1_020_000, first_seen_ms=first_seen, merge_distance_m=320.0)
+    max_r1 = max(float(r["radius_m"]) for r in regions_t1)
+    assert_true(max_r1 > max_r0, "随时间推进火区半径应增大")
+
+
+def test_empty_input() -> None:
+    first_seen: dict[str, int] = {}
+    regions = build_fire_regions([], now_ms=10, first_seen_ms=first_seen)
+    assert_true(regions == [], "空输入应返回空火区")
+
+
+def main() -> None:
+    test_cluster_and_growth()
+    test_empty_input()
+    print("test_fire_region_model: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/cesium_deck.html
+++ b/web/cesium_deck.html
@@ -107,12 +107,13 @@
     <script src="https://unpkg.com/cesium/Build/Cesium/Cesium.js"></script>
     <script src="https://unpkg.com/deck.gl@8.9.36/dist.min.js"></script>
     <script>
-      const state = { timestamp: 0, uavs: [], links: [], fire_hotspots: [], mission_targets: [] };
+      const state = { timestamp: 0, uavs: [], links: [], fire_hotspots: [], fire_regions: [], mission_targets: [] };
       const rows = document.getElementById('rows');
       const meta = document.getElementById('meta');
       let basemapMode = 'OSM';
       let osmErrorCount = 0;
       const forceBasemap = new URLSearchParams(window.location.search).get('basemap');
+      const fireRegionMode = new URLSearchParams(window.location.search).get('fire_region') !== 'off';
 
       Cesium.Ion.defaultAccessToken = undefined;
       const osmProvider = new Cesium.OpenStreetMapImageryProvider({
@@ -175,6 +176,7 @@
       const entityMap = new Map();
       const polylineMap = new Map();
       const hotspotMap = new Map();
+      const fireRegionMap = new Map();
       const missionLineMap = new Map();
 
       const deckgl = new deck.Deck({
@@ -352,6 +354,74 @@
         }
       }
 
+      function fireRegionColor(intensity) {
+        if (intensity >= 0.85) return Cesium.Color.fromBytes(185, 28, 28, 60);
+        if (intensity >= 0.6) return Cesium.Color.fromBytes(217, 119, 6, 56);
+        return Cesium.Color.fromBytes(202, 138, 4, 52);
+      }
+
+      function upsertFireRegions(regions) {
+        if (!fireRegionMode) {
+          for (const [k, e] of fireRegionMap.entries()) {
+            viewer.entities.remove(e);
+            fireRegionMap.delete(k);
+          }
+          return;
+        }
+
+        const live = new Set();
+        for (const r of regions || []) {
+          const rid = r.id || 'region';
+          live.add(rid);
+          const center = r.center || [0, 0, 0];
+          const lat = center[0];
+          const lon = center[1];
+          const alt = center[2] || 0;
+          const radius = Math.max(80.0, Number(r.radius_m || 120.0));
+          const color = fireRegionColor(Number(r.intensity || 0));
+          const label = `REGION ${rid} r=${radius.toFixed(0)}m n=${Number(r.member_count || 0)}`;
+          let e = fireRegionMap.get(rid);
+          if (!e) {
+            e = viewer.entities.add({
+              id: `fire_region:${rid}`,
+              position: Cesium.Cartesian3.fromDegrees(lon, lat, alt),
+              ellipse: {
+                semiMinorAxis: radius,
+                semiMajorAxis: radius,
+                height: 0,
+                material: color,
+                outline: true,
+                outlineColor: Cesium.Color.fromBytes(220, 38, 38, 120),
+                outlineWidth: 1
+              },
+              label: {
+                text: label,
+                font: '12px JetBrains Mono',
+                fillColor: Cesium.Color.fromBytes(252, 165, 165, 230),
+                style: Cesium.LabelStyle.FILL_AND_OUTLINE,
+                outlineColor: Cesium.Color.BLACK,
+                outlineWidth: 2,
+                verticalOrigin: Cesium.VerticalOrigin.BOTTOM,
+                pixelOffset: new Cesium.Cartesian2(0, -6)
+              }
+            });
+            fireRegionMap.set(rid, e);
+          } else {
+            e.position = Cesium.Cartesian3.fromDegrees(lon, lat, alt);
+            e.ellipse.semiMinorAxis = radius;
+            e.ellipse.semiMajorAxis = radius;
+            e.ellipse.material = color;
+            e.label.text = label;
+          }
+        }
+        for (const [id, entity] of fireRegionMap.entries()) {
+          if (!live.has(id)) {
+            viewer.entities.remove(entity);
+            fireRegionMap.delete(id);
+          }
+        }
+      }
+
       function upsertMissionLines(uavs, targets) {
         const uavById = new Map();
         for (const u of uavs) uavById.set(u.id, u.position);
@@ -459,6 +529,7 @@
           state.uavs = next.uavs || [];
           state.links = next.links || [];
           state.fire_hotspots = next.fire_hotspots || [];
+          state.fire_regions = next.fire_regions || [];
           state.mission_targets = next.mission_targets || [];
           const avgW = state.links.length
             ? (state.links.reduce((s, x) => s + x.weight, 0) / state.links.length).toFixed(3)
@@ -467,9 +538,10 @@
             ? Math.max(...state.fire_hotspots.map(x => x.intensity || 0)).toFixed(2)
             : 'n/a';
 
-          meta.innerHTML = `timestamp=${state.timestamp} <span class="badge">uav_count=${state.uavs.length}</span><span class="badge">link_count=${state.links.length}</span><span class="badge">avg_w=${avgW}</span><span class="badge">fire=${state.fire_hotspots.length}</span><span class="badge">max_fire=${maxFire}</span><span class="badge">mission=${state.mission_targets.length}</span><span class="badge">basemap=${basemapMode}</span>`;
+          meta.innerHTML = `timestamp=${state.timestamp} <span class="badge">uav_count=${state.uavs.length}</span><span class="badge">link_count=${state.links.length}</span><span class="badge">avg_w=${avgW}</span><span class="badge">fire=${state.fire_hotspots.length}</span><span class="badge">fire_regions=${state.fire_regions.length}</span><span class="badge">max_fire=${maxFire}</span><span class="badge">mission=${state.mission_targets.length}</span><span class="badge">basemap=${basemapMode}</span><span class="badge">fire_region=${fireRegionMode ? 'on' : 'off'}</span>`;
           upsertCesiumEntities(state.uavs);
           upsertCesiumLinks(state.uavs, state.links);
+          upsertFireRegions(state.fire_regions);
           upsertFireHotspots(state.fire_hotspots);
           upsertMissionLines(state.uavs, state.mission_targets);
           updateDeck(state.uavs, state.links);


### PR DESCRIPTION
## 背景
当前前端火情展示以热点点位为主，缺少可表达扩展趋势的连续火区层，不利于全景态势分析与算法演示。

## 关联 Issue
- Closes #3

## 改动点
1. 新增火区模型模块 `scripts/fire_region_model.py`
- 基于热点距离聚类（可配置阈值）形成火区。
- 结合热点强度与扩散速度估算火区半径，并随时间推进动态增长。
- 输出 `fire_regions` 结构，包含中心点、半径、强度、成员数量等字段。

2. 可视化服务接入 `fire_regions`
- 更新 `scripts/ros2_visualization_server.py`。
- 在接收 `FireState` 后，除保留 `fire_hotspots` 外，同步生成并缓存 `fire_regions`。
- `/api/swarm_state` 返回载荷新增 `fire_regions` 字段，实现双轨数据兼容。

3. 前端新增火区面图层
- 更新 `web/cesium_deck.html`。
- 新增 `fire_regions` 椭圆面渲染与标注，保留原热点点图层。
- 支持 URL 参数 `fire_region=off` 关闭火区面图层。
- 右上角状态摘要新增 `fire_regions` 计数与开关状态。

4. 文档与离线测试
- 更新 `README.md`，补充火区面图层说明和开关地址。
- 新增 `tests/test_fire_region_model.py`，提供无 ROS/PX4/Gazebo 依赖的离线算法验证。

## 影响范围
- `scripts/ros2_visualization_server.py`：API 载荷扩展。
- `web/cesium_deck.html`：新增火区图层渲染逻辑。
- `scripts/fire_region_model.py`：新增火区聚类与半径模型。
- `tests/test_fire_region_model.py`：新增离线单测。

## 验证步骤
1. `python3 -m py_compile scripts/fire_region_model.py scripts/ros2_visualization_server.py tests/test_fire_region_model.py`
2. `python3 tests/test_fire_region_model.py`
3. `bash -n scripts/fire_mission_demo_start.sh`
4. `bash -n scripts/fire_mission_demo_stop.sh`

## 验证结果
- 上述静态检查与离线测试通过。
- 受当前环境限制（未安装 ROS2/PX4/Gazebo），未执行运行态联调。

## 风险与回滚
- 风险：火区聚类阈值在不同场景下可能需要调参。
- 回滚：前端可通过 `fire_region=off` 关闭新图层；服务端可仅消费 `fire_hotspots` 保持兼容。
