### PR TITLE
chore: 提升 fire/visual demo 脚本稳定性并预留双视角启动能力

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
 
 - 默认首页为 Cesium + Deck.gl 版本
 - 旧版轻量页面：`http://127.0.0.1:8899/legacy`
+- 若目标端口被占用，启动脚本会自动回退到附近可用端口并打印实际端口
 
 ### 一键停止
 
@@ -203,6 +204,13 @@
 - 强制在线底图：`http://127.0.0.1:8899/cesium?basemap=osm`
 - 强制网格底图：`http://127.0.0.1:8899/cesium?basemap=grid`
 - 关闭火区面图层：`http://127.0.0.1:8899/cesium?fire_region=off`
+
+双视角演示预留脚本（Gazebo 特写 + 前端全景）：
+
+```bash
+./scripts/dual_view_demo_start.sh 4 4 8899 mock
+./scripts/dual_view_demo_stop.sh
+```
 
 ## 备注
 

--- a/scripts/demo_common.sh
+++ b/scripts/demo_common.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -u
+
+log_info() {
+  local tag="$1"
+  shift
+  echo "[${tag}][INFO] $*"
+}
+
+log_warn() {
+  local tag="$1"
+  shift
+  echo "[${tag}][WARN] $*" >&2
+}
+
+log_error() {
+  local tag="$1"
+  local code="$2"
+  shift 2
+  echo "[${tag}][ERROR][${code}] $*" >&2
+}
+
+pick_available_port() {
+  local base_port="$1"
+  local span="${2:-50}"
+  python3 - <<PY
+import socket
+base = int("${base_port}")
+span = int("${span}")
+for p in range(base, base + span):
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.bind(("127.0.0.1", p))
+        print(p)
+        break
+    except OSError:
+        pass
+    finally:
+        s.close()
+else:
+    print(-1)
+PY
+}
+
+kill_pid_graceful() {
+  local pid="$1"
+  if [[ -z "${pid}" ]]; then
+    return 0
+  fi
+  kill "${pid}" >/dev/null 2>&1 || true
+  for _ in $(seq 1 15); do
+    if ! kill -0 "${pid}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  kill -9 "${pid}" >/dev/null 2>&1 || true
+}
+
+kill_pattern() {
+  local pattern="$1"
+  pkill -f "${pattern}" >/dev/null 2>&1 || true
+  sleep 0.2
+  pkill -9 -f "${pattern}" >/dev/null 2>&1 || true
+}
+
+kill_port_listener() {
+  local port="$1"
+  if [[ -z "${port}" ]]; then
+    return 0
+  fi
+  local pids=""
+
+  if command -v lsof >/dev/null 2>&1; then
+    pids="$(lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null | sort -u || true)"
+  fi
+
+  if [[ -z "${pids}" ]] && command -v fuser >/dev/null 2>&1; then
+    pids="$(fuser -n tcp "${port}" 2>/dev/null | tr ' ' '\n' | sed '/^$/d' | sort -u || true)"
+  fi
+
+  if [[ -z "${pids}" ]]; then
+    pids="$(ss -ltnp 2>/dev/null | sed -n "s/.*:${port}[[:space:]].*pid=\([0-9]\+\).*/\1/p" | sort -u || true)"
+  fi
+
+  if [[ -n "${pids}" ]]; then
+    for p in ${pids}; do
+      kill_pid_graceful "${p}"
+    done
+  fi
+}
+

--- a/scripts/dual_view_demo_start.sh
+++ b/scripts/dual_view_demo_start.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TAG="dual_view_demo_start"
+PIDS_FILE="${ROOT_DIR}/.dual_view_demo_pids"
+source "${ROOT_DIR}/scripts/demo_common.sh"
+
+INSTANCE_COUNT="${1:-4}"
+TOTAL_CORES="${2:-4}"
+BASE_PORT="${3:-8899}"
+GAZEBO_MODE="${4:-mock}"
+GAZEBO_CMD="${GAZEBO_CMD:-}"
+
+"${ROOT_DIR}/scripts/dual_view_demo_stop.sh" >/dev/null 2>&1 || true
+
+"${ROOT_DIR}/scripts/visual_demo_start.sh" "${INSTANCE_COUNT}" "${TOTAL_CORES}" "${BASE_PORT}"
+VIS_PORT="$(cat "${ROOT_DIR}/.visual_demo_port" 2>/dev/null || echo "${BASE_PORT}")"
+
+GAZEBO_PID=""
+if [[ "${GAZEBO_MODE}" == "gazebo" ]]; then
+  if [[ -z "${GAZEBO_CMD}" ]]; then
+    log_error "${TAG}" "E_GAZEBO_CMD" "GAZEBO_MODE=gazebo 但未提供 GAZEBO_CMD"
+    "${ROOT_DIR}/scripts/visual_demo_stop.sh" >/dev/null 2>&1 || true
+    exit 21
+  fi
+  bash -lc "${GAZEBO_CMD}" > /tmp/dual_view_gazebo.log 2>&1 &
+  GAZEBO_PID=$!
+else
+  log_warn "${TAG}" "GAZEBO_MODE=${GAZEBO_MODE}，仅启动前端全景视图（特写窗口占位）"
+fi
+
+echo "${GAZEBO_PID}" > "${PIDS_FILE}"
+log_info "${TAG}" "started visual_port=${VIS_PORT} gazebo_mode=${GAZEBO_MODE} gazebo_pid=${GAZEBO_PID:-none}"
+log_info "${TAG}" "全景视图: http://127.0.0.1:${VIS_PORT}/cesium"

--- a/scripts/dual_view_demo_stop.sh
+++ b/scripts/dual_view_demo_stop.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TAG="dual_view_demo_stop"
+PIDS_FILE="${ROOT_DIR}/.dual_view_demo_pids"
+source "${ROOT_DIR}/scripts/demo_common.sh"
+
+if [[ -f "${PIDS_FILE}" ]]; then
+  read -r GAZEBO_PID < "${PIDS_FILE}" || true
+  kill_pid_graceful "${GAZEBO_PID:-}"
+  rm -f "${PIDS_FILE}"
+fi
+
+kill_pattern "gz sim"
+kill_pattern "gazebo --verbose"
+kill_pattern "ign gazebo"
+kill_pattern "px4_sitl_default/bin/px4"
+
+"${ROOT_DIR}/scripts/visual_demo_stop.sh" >/dev/null 2>&1 || true
+log_info "${TAG}" "stopped"

--- a/scripts/fire_mission_demo_check.sh
+++ b/scripts/fire_mission_demo_check.sh
@@ -2,35 +2,30 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${ROOT_DIR}/scripts/demo_common.sh"
 BASE_PORT="${1:-8899}"
 INSTANCE_COUNT="${2:-4}"
 TOTAL_CORES="${3:-4}"
+TAG="fire_mission_demo_check"
 
 set +u
 source /opt/ros/humble/setup.bash
 source "${ROOT_DIR}/ros2_ws/install/setup.bash"
 set -u
 
-PORT="$(python3 - <<PY
-import socket
-base = int("${BASE_PORT}")
-for p in range(base, base + 50):
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        s.bind(("127.0.0.1", p))
-        print(p)
-        break
-    except OSError:
-        pass
-    finally:
-        s.close()
-else:
-    print(base)
-PY
-)"
+PORT="$(pick_available_port "${BASE_PORT}" 50)"
+if [[ "${PORT}" == "-1" ]]; then
+  log_error "${TAG}" "E_PORT_FULL" "从端口 ${BASE_PORT} 起未找到可用端口"
+  exit 4
+fi
 
 "${ROOT_DIR}/scripts/fire_mission_demo_stop.sh" >/dev/null 2>&1 || true
-"${ROOT_DIR}/scripts/fire_mission_demo_start.sh" "${INSTANCE_COUNT}" "${TOTAL_CORES}" "${PORT}" >/tmp/fire_demo_start.log 2>&1
+if ! "${ROOT_DIR}/scripts/fire_mission_demo_start.sh" "${INSTANCE_COUNT}" "${TOTAL_CORES}" "${PORT}" >/tmp/fire_demo_start.log 2>&1; then
+  log_error "${TAG}" "E_START_FAIL" "启动 fire mission demo 失败"
+  echo "--- start log ---"
+  cat /tmp/fire_demo_start.log || true
+  exit 1
+fi
 
 cleanup() {
   "${ROOT_DIR}/scripts/fire_mission_demo_stop.sh" >/dev/null 2>&1 || true
@@ -134,7 +129,7 @@ if pos1 is None:
 move = distance_m(pos0, pos1)
 print(f"mission_msgs={probe.seen} target_count={probe.last} tracked_uav={tracked} moved_m={move:.2f}")
 if move < 2.0:
-    print("[fire_mission_demo_check] FAIL: UAV 位移过小，未观察到任务驱动运动")
+    print("[fire_mission_demo_check][ERROR][E_MOVE_SMALL] UAV 位移过小，未观察到任务驱动运动")
     raise SystemExit(1)
-print(f"[fire_mission_demo_check] PASS: 火场任务链路有效 (port={PORT})")
+print(f"[fire_mission_demo_check][INFO] PASS: 火场任务链路有效 (port={PORT})")
 PY

--- a/scripts/fire_mission_demo_start.sh
+++ b/scripts/fire_mission_demo_start.sh
@@ -4,42 +4,63 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PIDS_FILE="${ROOT_DIR}/.fire_demo_pids"
 PORT_FILE="${ROOT_DIR}/.fire_demo_port"
+TAG="fire_mission_demo_start"
+source "${ROOT_DIR}/scripts/demo_common.sh"
 
 INSTANCE_COUNT="${1:-4}"
 TOTAL_CORES="${2:-4}"
-VIS_PORT="${3:-8899}"
+BASE_PORT="${3:-8899}"
 FIRE_SOURCE_MODE="${4:-demo}"
 FDS_INPUT_PATH="${5:-${ROOT_DIR}/docs/examples/fds_hotspots_sample.csv}"
 FDS_INPUT_FORMAT="${6:-csv}"
+DRY_RUN="${DEMO_DRY_RUN:-0}"
+
+if [[ "${FIRE_SOURCE_MODE}" != "demo" && "${FIRE_SOURCE_MODE}" != "fds" ]]; then
+  log_error "${TAG}" "E_USAGE" "不支持的 FIRE_SOURCE_MODE=${FIRE_SOURCE_MODE}，可选: demo|fds"
+  exit 2
+fi
+
+if [[ "${FIRE_SOURCE_MODE}" == "fds" && ! -f "${FDS_INPUT_PATH}" ]]; then
+  log_error "${TAG}" "E_INPUT" "FDS 输入文件不存在: ${FDS_INPUT_PATH}"
+  exit 3
+fi
+
+VIS_PORT="$(pick_available_port "${BASE_PORT}" 50)"
+if [[ "${VIS_PORT}" == "-1" ]]; then
+  log_error "${TAG}" "E_PORT_FULL" "从端口 ${BASE_PORT} 起未找到可用端口"
+  exit 4
+fi
 
 "${ROOT_DIR}/scripts/fire_mission_demo_stop.sh" "${VIS_PORT}" >/dev/null 2>&1 || true
 "${ROOT_DIR}/scripts/visual_demo_stop.sh" >/dev/null 2>&1 || true
 
-if ! python3 - <<PY
-import socket,sys,time
-port=${VIS_PORT}
-deadline=time.time()+4.0
-while time.time()<deadline:
-    s=socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        s.bind(("127.0.0.1", port))
-        sys.exit(0)
-    except OSError:
-        time.sleep(0.2)
-    finally:
-        s.close()
-sys.exit(1)
-PY
-then
-  local_next_port="$((VIS_PORT + 1))"
-  echo "[fire_mission_demo_start] 端口 ${VIS_PORT} 已被占用，请换一个端口重试（例如 ${local_next_port}）"
-  exit 1
+if [[ "${DRY_RUN}" == "1" ]]; then
+  log_info "${TAG}" "DRY_RUN=1，跳过 ROS 进程启动"
+  log_info "${TAG}" "selected_port=${VIS_PORT} fire_source=${FIRE_SOURCE_MODE}"
+  exit 0
 fi
 
 set +u
-source /opt/ros/humble/setup.bash
-source "${ROOT_DIR}/ros2_ws/install/setup.bash"
+if [[ ! -f /opt/ros/humble/setup.bash ]]; then
+  set -u
+  log_error "${TAG}" "E_ROS_ENV" "缺少 /opt/ros/humble/setup.bash"
+  exit 5
+fi
+source /opt/ros/humble/setup.bash || {
+  set -u
+  log_error "${TAG}" "E_ROS_SOURCE" "加载 ROS 环境失败"
+  exit 6
+}
+source "${ROOT_DIR}/ros2_ws/install/setup.bash" || {
+  set -u
+  log_error "${TAG}" "E_WS_SOURCE" "加载工作区环境失败，请先构建 ros2_ws"
+  exit 7
+}
 set -u
+if ! command -v ros2 >/dev/null 2>&1; then
+  log_error "${TAG}" "E_ROS2_CMD" "未找到 ros2 命令"
+  exit 8
+fi
 
 mkdir -p /tmp/roslog
 export ROS_LOG_DIR=/tmp/roslog
@@ -77,9 +98,6 @@ elif [[ "${FIRE_SOURCE_MODE}" == "fds" ]]; then
     -p time_mode:=source_offset \
     > /tmp/fire_adapter_fds.log 2>&1 &
   FIRE_PID=$!
-else
-  echo "[fire_mission_demo_start] 不支持的 FIRE_SOURCE_MODE=${FIRE_SOURCE_MODE}，可选: demo|fds"
-  exit 1
 fi
 
 python3 "${ROOT_DIR}/scripts/mission_planner.py" \
@@ -93,5 +111,8 @@ VIS_PID=$!
 
 echo "${MANAGER_PID} ${TOPO_PID} ${FIRE_PID} ${PLANNER_PID} ${VIS_PID}" > "${PIDS_FILE}"
 echo "${VIS_PORT}" > "${PORT_FILE}"
-echo "[fire_mission_demo_start] manager=${MANAGER_PID} topo=${TOPO_PID} fire=${FIRE_PID} planner=${PLANNER_PID} vis=${VIS_PID} fire_source=${FIRE_SOURCE_MODE}"
-echo "[fire_mission_demo_start] 可视化: http://127.0.0.1:${VIS_PORT}/cesium"
+log_info "${TAG}" "manager=${MANAGER_PID} topo=${TOPO_PID} fire=${FIRE_PID} planner=${PLANNER_PID} vis=${VIS_PID} fire_source=${FIRE_SOURCE_MODE}"
+if [[ "${VIS_PORT}" != "${BASE_PORT}" ]]; then
+  log_warn "${TAG}" "端口 ${BASE_PORT} 被占用，已自动回退到 ${VIS_PORT}"
+fi
+log_info "${TAG}" "可视化: http://127.0.0.1:${VIS_PORT}/cesium"

--- a/scripts/fire_mission_demo_stop.sh
+++ b/scripts/fire_mission_demo_stop.sh
@@ -4,52 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PIDS_FILE="${ROOT_DIR}/.fire_demo_pids"
 PORT_FILE="${ROOT_DIR}/.fire_demo_port"
+TAG="fire_mission_demo_stop"
+source "${ROOT_DIR}/scripts/demo_common.sh"
 VIS_PORT="${1:-}"
-
-kill_pattern() {
-  local pattern="$1"
-  pkill -f "${pattern}" >/dev/null 2>&1 || true
-  sleep 0.2
-  pkill -9 -f "${pattern}" >/dev/null 2>&1 || true
-}
-
-kill_pid_graceful() {
-  local pid="$1"
-  kill "${pid}" >/dev/null 2>&1 || true
-  for _ in $(seq 1 10); do
-    if ! kill -0 "${pid}" >/dev/null 2>&1; then
-      return
-    fi
-    sleep 0.1
-  done
-  kill -9 "${pid}" >/dev/null 2>&1 || true
-}
-
-kill_port_listener() {
-  local port="$1"
-  if [[ -z "${port}" ]]; then
-    return
-  fi
-  local pids=""
-
-  if command -v lsof >/dev/null 2>&1; then
-    pids="$(lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null | sort -u || true)"
-  fi
-
-  if [[ -z "${pids}" ]] && command -v fuser >/dev/null 2>&1; then
-    pids="$(fuser -n tcp "${port}" 2>/dev/null | tr ' ' '\n' | sed '/^$/d' | sort -u || true)"
-  fi
-
-  if [[ -z "${pids}" ]]; then
-    pids="$(ss -ltnp 2>/dev/null | sed -n "s/.*:${port}[[:space:]].*pid=\([0-9]\+\).*/\1/p" | sort -u || true)"
-  fi
-
-  if [[ -n "${pids}" ]]; then
-    for p in ${pids}; do
-      kill_pid_graceful "${p}"
-    done
-  fi
-}
 
 if [[ -z "${VIS_PORT}" && -f "${PORT_FILE}" ]]; then
   VIS_PORT="$(cat "${PORT_FILE}" 2>/dev/null || true)"
@@ -73,4 +30,4 @@ kill_pattern "swarm_uav_manager_node"
 kill_pattern "ros2_visualization_server.py"
 kill_port_listener "${VIS_PORT}"
 rm -f "${PORT_FILE}"
-echo "[fire_mission_demo_stop] stopped"
+log_info "${TAG}" "stopped"

--- a/scripts/visual_demo_check.sh
+++ b/scripts/visual_demo_check.sh
@@ -2,30 +2,25 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${ROOT_DIR}/scripts/demo_common.sh"
 BASE_PORT="${1:-8899}"
 INSTANCE_COUNT="${2:-2}"
 TOTAL_CORES="${3:-2}"
+TAG="visual_demo_check"
 
-PORT="$(python3 - <<PY
-import socket
-base = int("${BASE_PORT}")
-for p in range(base, base + 50):
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        s.bind(("127.0.0.1", p))
-        print(p)
-        break
-    except OSError:
-        pass
-    finally:
-        s.close()
-else:
-    print(base)
-PY
-)"
+PORT="$(pick_available_port "${BASE_PORT}" 50)"
+if [[ "${PORT}" == "-1" ]]; then
+  log_error "${TAG}" "E_PORT_FULL" "从端口 ${BASE_PORT} 起未找到可用端口"
+  exit 4
+fi
 
 "${ROOT_DIR}/scripts/visual_demo_stop.sh" >/dev/null 2>&1 || true
-"${ROOT_DIR}/scripts/visual_demo_start.sh" "${INSTANCE_COUNT}" "${TOTAL_CORES}" "${PORT}" >/tmp/visual_demo_check_start.log 2>&1
+if ! "${ROOT_DIR}/scripts/visual_demo_start.sh" "${INSTANCE_COUNT}" "${TOTAL_CORES}" "${PORT}" >/tmp/visual_demo_check_start.log 2>&1; then
+  log_error "${TAG}" "E_START_FAIL" "启动 visual demo 失败"
+  echo "--- start log ---"
+  cat /tmp/visual_demo_check_start.log || true
+  exit 1
+fi
 
 cleanup() {
   "${ROOT_DIR}/scripts/visual_demo_stop.sh" >/dev/null 2>&1 || true
@@ -65,13 +60,15 @@ PY
 done
 
 if [[ "${ok}" -eq 1 ]]; then
-  echo "[visual_demo_check] PASS: 可视化 API 已返回 UAV 数据 (port=${PORT})"
+  log_info "${TAG}" "PASS: 可视化 API 已返回 UAV 数据 (port=${PORT})"
 else
-  echo "[visual_demo_check] FAIL: 可视化 API 未在超时内返回有效 UAV 数据"
+  log_error "${TAG}" "E_CHECK_TIMEOUT" "可视化 API 未在超时内返回有效 UAV 数据"
   echo "--- start log ---"
   cat /tmp/visual_demo_check_start.log || true
   echo "--- manager log ---"
   cat /tmp/swarm_manager.log || true
+  echo "--- topology log ---"
+  cat /tmp/swarm_topology.log || true
   echo "--- visual server log ---"
   cat /tmp/swarm_visual_server.log || true
   exit 1

--- a/scripts/visual_demo_start.sh
+++ b/scripts/visual_demo_start.sh
@@ -3,36 +3,53 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PIDS_FILE="${ROOT_DIR}/.visual_demo_pids"
+PORT_FILE="${ROOT_DIR}/.visual_demo_port"
+TAG="visual_demo_start"
+source "${ROOT_DIR}/scripts/demo_common.sh"
 
 INSTANCE_COUNT="${1:-4}"
 TOTAL_CORES="${2:-$(nproc)}"
-VIS_PORT="${3:-8899}"
+BASE_PORT="${3:-8899}"
+DRY_RUN="${DEMO_DRY_RUN:-0}"
 
 "${ROOT_DIR}/scripts/visual_demo_stop.sh" >/dev/null 2>&1 || true
 
-if ! python3 - <<PY
-import socket,sys
-port=${VIS_PORT}
-s=socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-try:
-    s.bind(("127.0.0.1", port))
-except OSError:
-    sys.exit(1)
-finally:
-    s.close()
-PY
-then
-  echo "[visual_demo_start] 端口 ${VIS_PORT} 已被占用，请更换端口后重试"
-  exit 1
+VIS_PORT="$(pick_available_port "${BASE_PORT}" 50)"
+if [[ "${VIS_PORT}" == "-1" ]]; then
+  log_error "${TAG}" "E_PORT_FULL" "从端口 ${BASE_PORT} 起未找到可用端口"
+  exit 4
+fi
+
+if [[ "${DRY_RUN}" == "1" ]]; then
+  log_info "${TAG}" "DRY_RUN=1，跳过 ROS/PX4 启动"
+  log_info "${TAG}" "selected_port=${VIS_PORT}"
+  exit 0
 fi
 
 set +u
-source /opt/ros/humble/setup.bash
-source "${ROOT_DIR}/ros2_ws/install/setup.bash"
+if [[ ! -f /opt/ros/humble/setup.bash ]]; then
+  set -u
+  log_error "${TAG}" "E_ROS_ENV" "缺少 /opt/ros/humble/setup.bash"
+  exit 5
+fi
+source /opt/ros/humble/setup.bash || {
+  set -u
+  log_error "${TAG}" "E_ROS_SOURCE" "加载 ROS 环境失败"
+  exit 6
+}
+source "${ROOT_DIR}/ros2_ws/install/setup.bash" || {
+  set -u
+  log_error "${TAG}" "E_WS_SOURCE" "加载工作区环境失败，请先构建 ros2_ws"
+  exit 7
+}
 set -u
+if ! command -v ros2 >/dev/null 2>&1; then
+  log_error "${TAG}" "E_ROS2_CMD" "未找到 ros2 命令"
+  exit 8
+fi
 
 if [[ ! -x "${ROOT_DIR}/third_party/PX4-Autopilot/build/px4_sitl_default/bin/px4" ]]; then
-  echo "[visual_demo_start] PX4 SITL not built, building..."
+  log_warn "${TAG}" "PX4 SITL 未构建，开始自动构建"
   (cd "${ROOT_DIR}/third_party/PX4-Autopilot" && CCACHE_DISABLE=1 make px4_sitl -j"$(nproc)")
 fi
 
@@ -60,5 +77,9 @@ SWARM_VIS_PORT="${VIS_PORT}" LD_LIBRARY_PATH="/opt/ros/humble/lib:/opt/ros/humbl
 SERVER_PID=$!
 
 echo "${MANAGER_PID} ${TOPO_PID} ${SERVER_PID}" > "${PIDS_FILE}"
-echo "[visual_demo_start] manager_pid=${MANAGER_PID} topo_pid=${TOPO_PID} server_pid=${SERVER_PID}"
-echo "[visual_demo_start] 打开浏览器: http://127.0.0.1:${VIS_PORT}"
+echo "${VIS_PORT}" > "${PORT_FILE}"
+log_info "${TAG}" "manager_pid=${MANAGER_PID} topo_pid=${TOPO_PID} server_pid=${SERVER_PID}"
+if [[ "${VIS_PORT}" != "${BASE_PORT}" ]]; then
+  log_warn "${TAG}" "端口 ${BASE_PORT} 被占用，已自动回退到 ${VIS_PORT}"
+fi
+log_info "${TAG}" "打开浏览器: http://127.0.0.1:${VIS_PORT}"

--- a/scripts/visual_demo_stop.sh
+++ b/scripts/visual_demo_stop.sh
@@ -3,29 +3,34 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PIDS_FILE="${ROOT_DIR}/.visual_demo_pids"
+PORT_FILE="${ROOT_DIR}/.visual_demo_port"
+TAG="visual_demo_stop"
+source "${ROOT_DIR}/scripts/demo_common.sh"
 
 if [[ ! -f "${PIDS_FILE}" ]]; then
-  pkill -f "ros2_visualization_server.py" 2>/dev/null || true
-  pkill -f "swarm_topology_analyzer_node" 2>/dev/null || true
-  pkill -f "swarm_uav_manager_node" 2>/dev/null || true
-  pkill -f "px4_sitl_default/bin/px4" 2>/dev/null || true
-  echo "[visual_demo_stop] no pid file, cleaned by process name"
+  kill_pattern "ros2_visualization_server.py"
+  kill_pattern "swarm_topology_analyzer_node"
+  kill_pattern "swarm_uav_manager_node"
+  kill_pattern "px4_sitl_default/bin/px4"
+  if [[ -f "${PORT_FILE}" ]]; then
+    kill_port_listener "$(cat "${PORT_FILE}" 2>/dev/null || true)"
+  fi
+  rm -f "${PORT_FILE}"
+  log_info "${TAG}" "no pid file, cleaned by process name"
   exit 0
 fi
 
 read -r MANAGER_PID TOPO_PID SERVER_PID < "${PIDS_FILE}" || true
 
-if [[ -n "${MANAGER_PID:-}" ]]; then
-  kill "${MANAGER_PID}" 2>/dev/null || true
-fi
-if [[ -n "${TOPO_PID:-}" ]]; then
-  kill "${TOPO_PID}" 2>/dev/null || true
-fi
-if [[ -n "${SERVER_PID:-}" ]]; then
-  kill "${SERVER_PID}" 2>/dev/null || true
-fi
+kill_pid_graceful "${MANAGER_PID:-}"
+kill_pid_graceful "${TOPO_PID:-}"
+kill_pid_graceful "${SERVER_PID:-}"
 
-pkill -f "px4_sitl_default/bin/px4" 2>/dev/null || true
+kill_pattern "px4_sitl_default/bin/px4"
+if [[ -f "${PORT_FILE}" ]]; then
+  kill_port_listener "$(cat "${PORT_FILE}" 2>/dev/null || true)"
+fi
 
 rm -f "${PIDS_FILE}"
-echo "[visual_demo_stop] stopped"
+rm -f "${PORT_FILE}"
+log_info "${TAG}" "stopped"

--- a/tests/test_demo_scripts.sh
+++ b/tests/test_demo_scripts.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+rm -f "${ROOT_DIR}/.visual_demo_port" "${ROOT_DIR}/.visual_demo_pids" "${ROOT_DIR}/.fire_demo_port" "${ROOT_DIR}/.fire_demo_pids"
+source "${ROOT_DIR}/scripts/demo_common.sh"
+
+occupy_port() {
+  local port="$1"
+  local ready_file="/tmp/test_demo_port_${port}.ready"
+  rm -f "${ready_file}"
+  python3 - <<PY &
+import socket, time, pathlib
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.bind(("127.0.0.1", int("${port}")))
+s.listen(1)
+pathlib.Path("${ready_file}").write_text("ok", encoding="utf-8")
+time.sleep(8)
+s.close()
+PY
+  for _ in $(seq 1 50); do
+    if [[ -f "${ready_file}" ]]; then
+      break
+    fi
+    sleep 0.05
+  done
+  if [[ ! -f "${ready_file}" ]]; then
+    echo "ASSERT FAILED: occupy_port not ready for ${port}"
+    exit 1
+  fi
+  if python3 - <<PY
+import socket, sys
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+try:
+    s.bind(("127.0.0.1", int("${port}")))
+    sys.exit(1)
+except OSError:
+    sys.exit(0)
+finally:
+    s.close()
+PY
+  then
+    :
+  else
+    echo "ASSERT FAILED: port ${port} not occupied as expected"
+    exit 1
+  fi
+  OCCUPY_PID=$!
+}
+
+assert_contains() {
+  local txt="$1"
+  local token="$2"
+  if [[ "${txt}" != *"${token}"* ]]; then
+    echo "ASSERT FAILED: expect contains '${token}'"
+    echo "actual: ${txt}"
+    exit 1
+  fi
+}
+
+BASE_PORT="$(python3 - <<'PY'
+import socket
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.bind(("127.0.0.1", 0))
+port = s.getsockname()[1]
+s.close()
+print(port)
+PY
+)"
+OCCUPY_PID=""
+occupy_port "${BASE_PORT}"
+LOCK_PID="${OCCUPY_PID}"
+trap 'kill "${LOCK_PID}" >/dev/null 2>&1 || true' EXIT
+
+FALLBACK_PORT="$(pick_available_port "${BASE_PORT}" 8)"
+if [[ "${FALLBACK_PORT}" != "$((BASE_PORT + 1))" ]]; then
+  echo "ASSERT FAILED: expect fallback port=$((BASE_PORT + 1)), actual=${FALLBACK_PORT}"
+  exit 1
+fi
+
+OUT1="$(DEMO_DRY_RUN=1 "${ROOT_DIR}/scripts/visual_demo_start.sh" 2 2 "${BASE_PORT}" 2>&1 || true)"
+assert_contains "${OUT1}" "[visual_demo_start][INFO] DRY_RUN=1"
+assert_contains "${OUT1}" "selected_port="
+
+OUT2="$(DEMO_DRY_RUN=1 "${ROOT_DIR}/scripts/fire_mission_demo_start.sh" 2 2 "${BASE_PORT}" demo 2>&1 || true)"
+assert_contains "${OUT2}" "[fire_mission_demo_start][INFO] DRY_RUN=1"
+assert_contains "${OUT2}" "selected_port="
+
+echo "test_demo_scripts: PASS"


### PR DESCRIPTION
## 背景
当前 fire/visual demo 脚本在端口冲突、异常退出、日志定位方面存在稳定性不足，影响重复验收效率；同时需要为双视角演示模式预留脚本入口。

## 关联 Issue
- Closes #4

## 改动点
1. 统一脚本公共能力
- 新增 `scripts/demo_common.sh`，封装统一日志格式、错误码输出、端口探测、进程优雅退出与端口监听清理。

2. 强化 fire/visual demo start/stop/check
- `fire_mission_demo_start.sh` / `visual_demo_start.sh`
  - 增加端口自动回退（base 起最多 50 个端口）。
  - 统一错误码（如 `E_PORT_FULL`, `E_ROS_ENV`, `E_ROS2_CMD`）。
  - 支持 `DEMO_DRY_RUN=1`，无 ROS/PX4 环境可跑流程测试。
- `fire_mission_demo_stop.sh` / `visual_demo_stop.sh`
  - 增强 PID + pattern + 端口监听三层清理，减少残留。
- `fire_mission_demo_check.sh` / `visual_demo_check.sh`
  - 启动失败时打印明确错误与日志。
  - 失败时补充更多关键日志输出，便于定位。

3. 双视角脚本预留（对接 #11）
- 新增 `scripts/dual_view_demo_start.sh`
- 新增 `scripts/dual_view_demo_stop.sh`
- 支持 `GAZEBO_MODE` 与 `GAZEBO_CMD`，当前可先 `mock` 模式运行全景视图，后续接入 Gazebo 特写命令。

4. 无依赖测试与文档
- 新增 `tests/test_demo_scripts.sh`（端口回退 + dry-run 行为验证）。
- 更新 `README.md`，补充自动端口回退与双视角预留脚本说明。

## 影响范围
- `scripts/` demo 启停与验收脚本行为发生增强，接口保持兼容。
- 新增双视角预留脚本，不影响现有单视图流程。

## 验证步骤
1. `bash -n scripts/demo_common.sh scripts/fire_mission_demo_start.sh scripts/fire_mission_demo_stop.sh scripts/fire_mission_demo_check.sh scripts/visual_demo_start.sh scripts/visual_demo_stop.sh scripts/visual_demo_check.sh scripts/dual_view_demo_start.sh scripts/dual_view_demo_stop.sh tests/test_demo_scripts.sh`
2. `tests/test_demo_scripts.sh`

## 验证结果
- 上述语法检查与离线脚本测试通过。
- 受当前环境限制（未安装 ROS2/PX4/Gazebo），未执行运行态在线联调与 10 轮压力验收。

## 风险与回滚
- 风险：stop 清理范围扩大，存在误杀同名进程可能。
- 回滚：可回退到前一版脚本，或保留 `DEMO_DRY_RUN`/端口回退开关并逐步灰度启用。
