### PR TITLE
feat: 完善双视角并列演示并新增同步性验收链路

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,14 @@
 ./scripts/dual_view_demo_stop.sh
 ```
 
+双视角同步验收：
+
+```bash
+./scripts/dual_view_demo_check.sh 8899 2 2 mock 30.0 2500
+```
+
+布局建议与排障说明见：`docs/dual-view-demo.md`
+
 ## 备注
 
 - 拓扑分析当前为阶段算法（距离 + 高度差遮挡近似），已通过统一 `links` 接口输出。

--- a/docs/dual-view-demo.md
+++ b/docs/dual-view-demo.md
@@ -1,0 +1,65 @@
+# 双视角并列演示（Gazebo 特写 + 前端全景）
+
+本文档用于说明双视角演示模式的布局、启动方式、同步检查与排障。
+
+## 1. 布局规范
+
+建议采用固定并列布局：
+
+- 左侧 40%：Gazebo 特写窗口（局部姿态、机动细节）。
+- 右侧 60%：前端全景窗口（火区、链路、任务、全体 UAV）。
+
+此布局为建议值，可根据显示器调整，但建议保持“左特写、右全景”一致。
+
+## 2. 一键启动/停止
+
+启动（mock 特写源）：
+
+```bash
+./scripts/dual_view_demo_start.sh 4 4 8899 mock
+```
+
+启动（真实 Gazebo 特写进程）：
+
+```bash
+GAZEBO_CMD='gz sim your_world.sdf' ./scripts/dual_view_demo_start.sh 4 4 8899 gazebo
+```
+
+停止：
+
+```bash
+./scripts/dual_view_demo_stop.sh
+```
+
+## 3. 同步性验收
+
+执行双视角同步检查（默认阈值：距离 <= 30m，时间差 <= 2500ms）：
+
+```bash
+./scripts/dual_view_demo_check.sh 8899 2 2 mock 30.0 2500
+```
+
+输出示例：
+
+- `samples=8 max_dist_m=... max_dt_ms=... uid=...`
+- `[dual_view_demo_check][INFO] PASS: 双视角同步检查通过 ...`
+
+## 4. 对齐策略
+
+- 统一 UAV ID：特写与全景均按 `uav_id` 关联同一对象。
+- 统一时间戳：同步检查按毫秒级时间戳比较。
+- 轨迹偏差：以经纬高三维距离计算误差阈值。
+
+## 5. 常见问题排查
+
+1. 启动失败（`E_START_FAIL`）  
+查看 `/tmp/dual_view_start.log` 与 visual/fire 相关日志。
+
+2. 同步失败（`E_SYNC`）  
+先检查特写源是否返回 `ok=true`，再检查 ID 是否匹配、时间戳是否同源。
+
+3. 端口冲突  
+脚本会自动回退到附近端口；实际端口记录在 `.dual_view_demo_pids`。
+
+4. 无 Gazebo 环境  
+先用 `mock` 模式完成链路与同步脚本验收，后续切换 `gazebo` 模式。

--- a/scripts/dual_view_demo_check.sh
+++ b/scripts/dual_view_demo_check.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${ROOT_DIR}/scripts/demo_common.sh"
+TAG="dual_view_demo_check"
+
+BASE_PORT="${1:-8899}"
+INSTANCE_COUNT="${2:-2}"
+TOTAL_CORES="${3:-2}"
+GAZEBO_MODE="${4:-mock}"
+MAX_DIST_M="${5:-30.0}"
+MAX_DT_MS="${6:-2500}"
+
+"${ROOT_DIR}/scripts/dual_view_demo_stop.sh" >/dev/null 2>&1 || true
+if ! "${ROOT_DIR}/scripts/dual_view_demo_start.sh" "${INSTANCE_COUNT}" "${TOTAL_CORES}" "${BASE_PORT}" "${GAZEBO_MODE}" >/tmp/dual_view_start.log 2>&1; then
+  log_error "${TAG}" "E_START_FAIL" "启动 dual view 失败"
+  echo "--- start log ---"
+  cat /tmp/dual_view_start.log || true
+  exit 1
+fi
+
+cleanup() {
+  "${ROOT_DIR}/scripts/dual_view_demo_stop.sh" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+if [[ ! -f "${ROOT_DIR}/.dual_view_demo_pids" ]]; then
+  log_error "${TAG}" "E_NO_PID_FILE" "缺少 .dual_view_demo_pids"
+  exit 2
+fi
+
+read -r _ _ VIS_PORT FOCUS_PORT _ < "${ROOT_DIR}/.dual_view_demo_pids" || true
+if [[ -z "${VIS_PORT}" || -z "${FOCUS_PORT}" ]]; then
+  log_error "${TAG}" "E_PID_PARSE" "无法解析 dual view 端口信息"
+  exit 3
+fi
+
+python3 - <<PY
+import json
+import time
+import urllib.request
+import sys
+from pathlib import Path
+
+ROOT = Path("${ROOT_DIR}")
+sys.path.insert(0, str(ROOT / "scripts"))
+from dual_view_sync import evaluate_sync  # noqa: E402
+
+vis_url = "http://127.0.0.1:${VIS_PORT}/api/swarm_state"
+focus_url = "http://127.0.0.1:${FOCUS_PORT}/api/gazebo_focus_state"
+max_dist_m = float("${MAX_DIST_M}")
+max_dt_ms = int("${MAX_DT_MS}")
+
+proxy_handler = urllib.request.ProxyHandler({})
+opener = urllib.request.build_opener(proxy_handler)
+
+def fetch_json(url: str):
+    raw = opener.open(url, timeout=1.5).read().decode("utf-8")
+    return json.loads(raw)
+
+def pick_uav(state, uid):
+    for u in state.get("uavs", []):
+        if u.get("id") == uid:
+            return u
+    return None
+
+pairs = []
+target_uid = None
+deadline = time.time() + 15.0
+while time.time() < deadline and len(pairs) < 8:
+    try:
+        vis = fetch_json(vis_url)
+        focus = fetch_json(focus_url)
+        if not isinstance(vis, dict) or not isinstance(focus, dict):
+            time.sleep(0.3)
+            continue
+        if not focus.get("ok"):
+            time.sleep(0.3)
+            continue
+        fu = focus.get("uav", {})
+        if target_uid is None:
+            target_uid = fu.get("id")
+        if not target_uid:
+            time.sleep(0.3)
+            continue
+        vu = pick_uav(vis, target_uid)
+        if vu is None:
+            time.sleep(0.3)
+            continue
+        pairs.append((
+            int(vis.get("timestamp", 0)),
+            [float(vu["position"][0]), float(vu["position"][1]), float(vu["position"][2])],
+            int(focus.get("timestamp", 0)),
+            [float(fu["position"][0]), float(fu["position"][1]), float(fu["position"][2])],
+        ))
+    except Exception:
+        pass
+    time.sleep(0.35)
+
+result = evaluate_sync(pairs, max_dist_m=max_dist_m, max_time_diff_ms=max_dt_ms)
+print(f"samples={result['samples']} max_dist_m={result['max_dist_m']:.3f} max_dt_ms={result['max_dt_ms']} uid={target_uid}")
+if not result["ok"]:
+    print(f"[dual_view_demo_check][ERROR][E_SYNC] reason={result['reason']} thresholds(dist={max_dist_m},dt={max_dt_ms})")
+    raise SystemExit(1)
+print(f"[dual_view_demo_check][INFO] PASS: 双视角同步检查通过 (vis_port=${VIS_PORT}, focus_port=${FOCUS_PORT})")
+PY

--- a/scripts/dual_view_demo_start.sh
+++ b/scripts/dual_view_demo_start.sh
@@ -11,13 +11,28 @@ TOTAL_CORES="${2:-4}"
 BASE_PORT="${3:-8899}"
 GAZEBO_MODE="${4:-mock}"
 GAZEBO_CMD="${GAZEBO_CMD:-}"
+DUAL_UAV_ID="${5:-}"
+FOCUS_BASE_PORT="${DUAL_FOCUS_BASE_PORT:-$((BASE_PORT + 120))}"
+DRY_RUN="${DEMO_DRY_RUN:-0}"
 
 "${ROOT_DIR}/scripts/dual_view_demo_stop.sh" >/dev/null 2>&1 || true
 
+if [[ "${DRY_RUN}" == "1" ]]; then
+  log_info "${TAG}" "DRY_RUN=1，跳过双视角进程启动"
+  exit 0
+fi
+
 "${ROOT_DIR}/scripts/visual_demo_start.sh" "${INSTANCE_COUNT}" "${TOTAL_CORES}" "${BASE_PORT}"
 VIS_PORT="$(cat "${ROOT_DIR}/.visual_demo_port" 2>/dev/null || echo "${BASE_PORT}")"
+FOCUS_PORT="$(pick_available_port "${FOCUS_BASE_PORT}" 50)"
+if [[ "${FOCUS_PORT}" == "-1" ]]; then
+  log_error "${TAG}" "E_FOCUS_PORT" "未找到可用 focus 端口"
+  "${ROOT_DIR}/scripts/visual_demo_stop.sh" >/dev/null 2>&1 || true
+  exit 22
+fi
 
 GAZEBO_PID=""
+FOCUS_PID=""
 if [[ "${GAZEBO_MODE}" == "gazebo" ]]; then
   if [[ -z "${GAZEBO_CMD}" ]]; then
     log_error "${TAG}" "E_GAZEBO_CMD" "GAZEBO_MODE=gazebo 但未提供 GAZEBO_CMD"
@@ -26,10 +41,17 @@ if [[ "${GAZEBO_MODE}" == "gazebo" ]]; then
   fi
   bash -lc "${GAZEBO_CMD}" > /tmp/dual_view_gazebo.log 2>&1 &
   GAZEBO_PID=$!
+elif [[ "${GAZEBO_MODE}" == "mock" ]]; then
+  DUAL_VIS_PORT="${VIS_PORT}" DUAL_FOCUS_PORT="${FOCUS_PORT}" DUAL_UAV_ID="${DUAL_UAV_ID}" \
+    python3 "${ROOT_DIR}/scripts/dual_view_focus_mock_server.py" > /tmp/dual_view_focus_mock.log 2>&1 &
+  FOCUS_PID=$!
 else
   log_warn "${TAG}" "GAZEBO_MODE=${GAZEBO_MODE}，仅启动前端全景视图（特写窗口占位）"
 fi
 
-echo "${GAZEBO_PID}" > "${PIDS_FILE}"
-log_info "${TAG}" "started visual_port=${VIS_PORT} gazebo_mode=${GAZEBO_MODE} gazebo_pid=${GAZEBO_PID:-none}"
+echo "${GAZEBO_PID} ${FOCUS_PID} ${VIS_PORT} ${FOCUS_PORT} ${GAZEBO_MODE}" > "${PIDS_FILE}"
+log_info "${TAG}" "started visual_port=${VIS_PORT} focus_port=${FOCUS_PORT} gazebo_mode=${GAZEBO_MODE} gazebo_pid=${GAZEBO_PID:-none} focus_pid=${FOCUS_PID:-none}"
 log_info "${TAG}" "全景视图: http://127.0.0.1:${VIS_PORT}/cesium"
+if [[ "${GAZEBO_MODE}" == "mock" ]]; then
+  log_info "${TAG}" "特写状态接口(mock): http://127.0.0.1:${FOCUS_PORT}/api/gazebo_focus_state"
+fi

--- a/scripts/dual_view_demo_stop.sh
+++ b/scripts/dual_view_demo_stop.sh
@@ -7,11 +7,13 @@ PIDS_FILE="${ROOT_DIR}/.dual_view_demo_pids"
 source "${ROOT_DIR}/scripts/demo_common.sh"
 
 if [[ -f "${PIDS_FILE}" ]]; then
-  read -r GAZEBO_PID < "${PIDS_FILE}" || true
+  read -r GAZEBO_PID FOCUS_PID _ _ _ < "${PIDS_FILE}" || true
   kill_pid_graceful "${GAZEBO_PID:-}"
+  kill_pid_graceful "${FOCUS_PID:-}"
   rm -f "${PIDS_FILE}"
 fi
 
+kill_pattern "dual_view_focus_mock_server.py"
 kill_pattern "gz sim"
 kill_pattern "gazebo --verbose"
 kill_pattern "ign gazebo"

--- a/scripts/dual_view_focus_mock_server.py
+++ b/scripts/dual_view_focus_mock_server.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+VIS_PORT = int(os.environ.get("DUAL_VIS_PORT", "8899"))
+FOCUS_PORT = int(os.environ.get("DUAL_FOCUS_PORT", "8900"))
+TARGET_UAV_ID = os.environ.get("DUAL_UAV_ID", "").strip()
+VIS_URL = os.environ.get("DUAL_VIS_URL", f"http://127.0.0.1:{VIS_PORT}/api/swarm_state")
+
+_proxy_handler = urllib.request.ProxyHandler({})
+_opener = urllib.request.build_opener(_proxy_handler)
+
+
+def fetch_swarm_state() -> dict:
+    raw = _opener.open(VIS_URL, timeout=1.2).read().decode("utf-8")
+    obj = json.loads(raw)
+    if not isinstance(obj, dict):
+        return {}
+    return obj
+
+
+def pick_uav(state: dict) -> dict | None:
+    uavs = state.get("uavs", [])
+    if not isinstance(uavs, list) or not uavs:
+        return None
+    if TARGET_UAV_ID:
+        for u in uavs:
+            if isinstance(u, dict) and u.get("id") == TARGET_UAV_ID:
+                return u
+        return None
+    for u in uavs:
+        if isinstance(u, dict) and "id" in u and "position" in u:
+            return u
+    return None
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        if self.path != "/api/gazebo_focus_state":
+            self.send_response(HTTPStatus.NOT_FOUND)
+            self.end_headers()
+            return
+
+        try:
+            state = fetch_swarm_state()
+            u = pick_uav(state)
+            if u is None:
+                payload = {
+                    "ok": False,
+                    "error": "no_uav",
+                    "source": "mock_from_visual",
+                }
+            else:
+                payload = {
+                    "ok": True,
+                    "source": "mock_from_visual",
+                    "timestamp": int(state.get("timestamp", 0)),
+                    "uav": {
+                        "id": u.get("id", ""),
+                        "position": list(u.get("position", [0.0, 0.0, 0.0])),
+                    },
+                }
+        except Exception as ex:
+            payload = {
+                "ok": False,
+                "error": str(ex),
+                "source": "mock_from_visual",
+            }
+
+        raw = json.dumps(payload).encode("utf-8")
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def log_message(self, format: str, *args) -> None:
+        return
+
+
+def main() -> None:
+    server = ThreadingHTTPServer(("0.0.0.0", FOCUS_PORT), Handler)
+    print(f"[dual_focus_mock] serving http://127.0.0.1:{FOCUS_PORT}/api/gazebo_focus_state")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dual_view_sync.py
+++ b/scripts/dual_view_sync.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import math
+from typing import Iterable, List, Tuple
+
+
+def distance_m(a: List[float], b: List[float]) -> float:
+    dlat = (a[0] - b[0]) * 111000.0
+    mid_lat = (a[0] + b[0]) * 0.5
+    dlon = (a[1] - b[1]) * 111000.0 * math.cos(math.radians(mid_lat))
+    dalt = a[2] - b[2]
+    return math.sqrt(dlat * dlat + dlon * dlon + dalt * dalt)
+
+
+def evaluate_sync(
+    pairs: Iterable[Tuple[int, List[float], int, List[float]]],
+    max_dist_m: float,
+    max_time_diff_ms: int,
+) -> dict:
+    rows = list(pairs)
+    if not rows:
+        return {
+            "ok": False,
+            "samples": 0,
+            "max_dist_m": 0.0,
+            "max_dt_ms": 0,
+            "reason": "no_samples",
+        }
+
+    max_dist = 0.0
+    max_dt = 0
+    for vis_ts, vis_pos, focus_ts, focus_pos in rows:
+        d = distance_m(vis_pos, focus_pos)
+        dt = abs(int(vis_ts) - int(focus_ts))
+        max_dist = max(max_dist, d)
+        max_dt = max(max_dt, dt)
+
+    ok = (max_dist <= max_dist_m) and (max_dt <= max_time_diff_ms)
+    return {
+        "ok": ok,
+        "samples": len(rows),
+        "max_dist_m": max_dist,
+        "max_dt_ms": max_dt,
+        "reason": "ok" if ok else "threshold_exceeded",
+    }

--- a/tests/test_dual_view_sync.py
+++ b/tests/test_dual_view_sync.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from dual_view_sync import evaluate_sync  # noqa: E402
+
+
+def assert_true(cond: bool, msg: str) -> None:
+    if not cond:
+        raise AssertionError(msg)
+
+
+def test_pass_case() -> None:
+    pairs = [
+        (1000, [39.90, 116.40, 100.0], 1050, [39.90001, 116.40001, 101.0]),
+        (1500, [39.9002, 116.4003, 100.0], 1520, [39.90021, 116.40029, 100.8]),
+    ]
+    r = evaluate_sync(pairs, max_dist_m=40.0, max_time_diff_ms=1000)
+    assert_true(r["ok"], "应通过同步检查")
+    assert_true(r["samples"] == 2, "样本计数应正确")
+
+
+def test_fail_case() -> None:
+    pairs = [
+        (1000, [39.90, 116.40, 100.0], 5000, [39.91, 116.42, 180.0]),
+    ]
+    r = evaluate_sync(pairs, max_dist_m=30.0, max_time_diff_ms=1000)
+    assert_true(not r["ok"], "应触发阈值失败")
+
+
+def test_empty_case() -> None:
+    r = evaluate_sync([], max_dist_m=30.0, max_time_diff_ms=1000)
+    assert_true(not r["ok"], "空样本不应通过")
+    assert_true(r["reason"] == "no_samples", "空样本原因应为 no_samples")
+
+
+def main() -> None:
+    test_pass_case()
+    test_fail_case()
+    test_empty_case()
+    print("test_dual_view_sync: PASS")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 背景
需要将 Gazebo 特写与前端全景形成可执行的双视角并列演示流程，并具备可量化的同步性验收能力。

## 关联 Issue
- Closes #11

## 改动点
1. 完善双视角一键启停脚本
- 更新 `scripts/dual_view_demo_start.sh`：
  - 支持 `mock/gazebo` 两种模式。
  - 自动分配并输出特写接口端口（focus_port）。
  - 记录双视角运行状态到 `.dual_view_demo_pids`。
- 更新 `scripts/dual_view_demo_stop.sh`：
  - 清理 Gazebo 与 focus mock 相关进程。

2. 新增特写状态 mock 服务
- 新增 `scripts/dual_view_focus_mock_server.py`。
- 从全景 `api/swarm_state` 生成特写 `api/gazebo_focus_state`，统一 `uav_id` 与时间戳结构。

3. 新增双视角同步性验收
- 新增 `scripts/dual_view_sync.py`：同步距离/时间偏差评估。
- 新增 `scripts/dual_view_demo_check.sh`：
  - 自动启动双视角模式。
  - 采样并比较全景与特写同一 UAV 轨迹。
  - 输出 `samples/max_dist_m/max_dt_ms` 与 PASS/FAIL。

4. 文档与测试
- 新增 `docs/dual-view-demo.md`（布局建议 40/60、启动方式、同步检查、排障）。
- 更新 `README.md`，补充双视角同步验收命令。
- 新增 `tests/test_dual_view_sync.py`（离线单测）。

## 影响范围
- `scripts/`：新增双视角验收链路与 mock 特写服务。
- `docs/`：新增双视角演示指南。
- 现有单前端演示路径保持不变。

## 验证步骤
1. `bash -n scripts/dual_view_demo_start.sh scripts/dual_view_demo_stop.sh scripts/dual_view_demo_check.sh`
2. `python3 -m py_compile scripts/dual_view_sync.py scripts/dual_view_focus_mock_server.py tests/test_dual_view_sync.py`
3. `python3 tests/test_dual_view_sync.py`
4. `DEMO_DRY_RUN=1 scripts/dual_view_demo_start.sh 2 2 8899 mock && scripts/dual_view_demo_stop.sh`

## 验证结果
- 上述离线验证通过。
- 受当前环境限制（未安装 ROS2/PX4/Gazebo），未执行真实 Gazebo 在线联调。

## 风险与回滚
- 风险：mock 特写链路与真实 Gazebo 状态接口字段可能存在差异。
- 回滚：双视角作为可选路径，不影响现有 visual/fire demo 主链路。
