### PR TITLE
P1-3：新增压测与任务验收指标（延迟/掉包/完成时延）

### DIFF
--- a/docs/next-plan.md
+++ b/docs/next-plan.md
@@ -32,7 +32,7 @@
 - 计划：接入地形/场景遮挡接口，保留现有近似模式作 fallback。
 
 3. 压测指标体系完善
-- 当前：`observed_hz` + `context_switch_hz` + 拓扑帧耗时。
+- 当前：在 `scripts/stress_100hz.sh` 增加端到端延迟与掉包率统计（p95 延迟、drop_ratio）。
 - 计划：增加端到端延迟、掉包率、任务完成时延统计。
 
 ## P2（后续扩展）

--- a/docs/ros2-dev.md
+++ b/docs/ros2-dev.md
@@ -121,10 +121,11 @@
 说明：
 
 - 脚本会启动 manager + topology，并持续采集 `/swarm/state` 消息数。
-- 统计结果会输出：`observed_hz`、`context_switch_hz`、拓扑 `profile status`。
+- 统计结果会输出：`observed_hz`、`context_switch_hz`、拓扑 `profile status`、`e2e_latency_ms(avg/p95)`、`drop_ratio`、`interval_ms(jitter/max)`。
 - 当前通过标准：
   - 拓扑 `status=PASS`
   - `observed_hz >= 0.8 * target_hz`
+  - `drop_ratio <= 0.20`
 
 ## Fire Mission MVP（模拟 FDS 输出）
 
@@ -151,6 +152,7 @@
 - 验收脚本会验证：
   - mission 目标已发布
   - 至少一架被分配任务的 UAV 在观测窗口内产生明显位移
+  - mission 完成时延统计（`completion_s`）
 
 ## 快速查看状态
 

--- a/scripts/fire_mission_demo_check.sh
+++ b/scripts/fire_mission_demo_check.sh
@@ -51,12 +51,6 @@ def fetch_state():
     data = opener.open(url, timeout=1.5).read().decode("utf-8")
     return json.loads(data)
 
-def pick_one(state):
-    if not state.get("uavs"):
-        return None, None
-    u = state["uavs"][0]
-    return u["id"], u["position"]
-
 def distance_m(a, b):
     dlat = (a[0] - b[0]) * 111000.0
     dlon = (a[1] - b[1]) * 111000.0
@@ -70,19 +64,24 @@ class PlanProbe(Node):
         self.seen = 0
         self.last = 0
         self.tracked_id = None
+        self.target_position = None
+        self.assign_time = None
         self.create_subscription(MissionPlan, "/swarm/mission_targets", self._cb, 10)
     def _cb(self, msg: MissionPlan):
         self.seen += 1
         self.last = len(msg.targets)
         if msg.targets:
             self.tracked_id = msg.targets[0].uav_id
+            if self.target_position is None:
+                self.target_position = list(msg.targets[0].position)
+                self.assign_time = time.time()
 
 probe = PlanProbe()
 deadline = time.time() + 8
 while time.time() < deadline and probe.seen == 0:
     rclpy.spin_once(probe, timeout_sec=0.2)
 
-if probe.seen == 0 or probe.last == 0 or not probe.tracked_id:
+if probe.seen == 0 or probe.last == 0 or not probe.tracked_id or not probe.target_position:
     print("[fire_mission_demo_check] FAIL: mission planner 未产出目标")
     probe.destroy_node()
     rclpy.shutdown()
@@ -106,6 +105,8 @@ if state0 is None:
     raise SystemExit(1)
 
 tracked = probe.tracked_id
+target_pos = probe.target_position
+assign_time = probe.assign_time or time.time()
 def pick_by_id(state, uid):
     for u in state.get("uavs", []):
         if u.get("id") == uid:
@@ -116,18 +117,35 @@ pos0 = pick_by_id(state0, tracked)
 if pos0 is None:
     print("[fire_mission_demo_check] FAIL: 在初始状态中未找到被分配任务的 UAV")
     raise SystemExit(1)
-time.sleep(3.0)
-state1 = fetch_state()
-pos1 = pick_by_id(state1, tracked)
+completion_sec = None
+deadline = time.time() + 10.0
+pos1 = None
+while time.time() < deadline:
+    state1 = fetch_state()
+    pos1 = pick_by_id(state1, tracked)
+    if pos1 is None:
+        time.sleep(0.2)
+        continue
+    if distance_m(pos1, target_pos) <= 8.0:
+        completion_sec = time.time() - assign_time
+        break
+    time.sleep(0.2)
+
 probe.destroy_node()
 rclpy.shutdown()
 
+if completion_sec is None:
+    print("[fire_mission_demo_check][ERROR][E_MISSION_TIMEOUT] 未在窗口内完成任务")
+    raise SystemExit(1)
 if pos1 is None:
-    print("[fire_mission_demo_check] FAIL: 在后续状态中未找到被分配任务的 UAV")
+    print("[fire_mission_demo_check][ERROR][E_MISSION_TRACK_LOSS] 在后续状态中未找到被分配任务的 UAV")
     raise SystemExit(1)
 
 move = distance_m(pos0, pos1)
-print(f"mission_msgs={probe.seen} target_count={probe.last} tracked_uav={tracked} moved_m={move:.2f}")
+print(
+    f"mission_msgs={probe.seen} target_count={probe.last} tracked_uav={tracked} "
+    f"moved_m={move:.2f} completion_s={completion_sec:.2f}"
+)
 if move < 2.0:
     print("[fire_mission_demo_check][ERROR][E_MOVE_SMALL] UAV 位移过小，未观察到任务驱动运动")
     raise SystemExit(1)

--- a/scripts/stress_100hz.sh
+++ b/scripts/stress_100hz.sh
@@ -49,7 +49,7 @@ sleep 1
 
 ctxt_before="$(awk '/^ctxt /{print $2}' /proc/stat)"
 
-msg_count="$(python3 - <<PY
+stats_json="$(python3 - <<PY
 import time
 import rclpy
 from rclpy.node import Node
@@ -57,23 +57,85 @@ from swarm_interfaces.msg import SwarmState
 
 DURATION = float("${DURATION_SECONDS}")
 TOPIC = "/swarm/state"
+TARGET_HZ = float("${PUBLISH_HZ}")
 
 class Counter(Node):
     def __init__(self) -> None:
         super().__init__("swarm_stress_counter")
         self.count = 0
+        self.latencies_ms = []
+        self.intervals_ms = []
+        self.last_stamp_ns = None
         self.create_subscription(SwarmState, TOPIC, self.cb, 50)
-    def cb(self, _msg: SwarmState) -> None:
+    def cb(self, msg: SwarmState) -> None:
         self.count += 1
+        if not (msg.stamp.sec or msg.stamp.nanosec):
+            return
+        stamp_ns = msg.stamp.sec * 1_000_000_000 + msg.stamp.nanosec
+        now_ns = time.time_ns()
+        latency_ms = max(0.0, (now_ns - stamp_ns) / 1_000_000.0)
+        self.latencies_ms.append(latency_ms)
+        if self.last_stamp_ns is not None:
+            interval_ms = (stamp_ns - self.last_stamp_ns) / 1_000_000.0
+            if interval_ms > 0.0:
+                self.intervals_ms.append(interval_ms)
+        self.last_stamp_ns = stamp_ns
 
 rclpy.init()
 node = Counter()
 end = time.time() + DURATION
 while time.time() < end:
     rclpy.spin_once(node, timeout_sec=0.1)
-print(node.count)
+
+if node.count > 0 and node.latencies_ms:
+    lat = sorted(node.latencies_ms)
+    avg_latency = sum(node.latencies_ms) / len(node.latencies_ms)
+    p50_latency = lat[len(lat)//2]
+    p95_latency = lat[int(len(lat)*0.95)-1] if len(lat) > 1 else lat[0]
+else:
+    avg_latency = 0.0
+    p50_latency = 0.0
+    p95_latency = 0.0
+
+if node.intervals_ms:
+    interval_jitter = max(node.intervals_ms) - min(node.intervals_ms)
+    max_gap = max(node.intervals_ms)
+    avg_gap = sum(node.intervals_ms) / len(node.intervals_ms)
+else:
+    interval_jitter = 0.0
+    max_gap = 0.0
+    avg_gap = 0.0
+
+expected = int(TARGET_HZ * DURATION)
+drop_ratio = 0.0 if expected <= 0 else max(0.0, 1.0 - (node.count / float(expected)))
+print(
+    '{'
+    f'"count": {node.count}, '
+    f'"avg_latency_ms": {avg_latency:.3f}, '
+    f'"p50_latency_ms": {p50_latency:.3f}, '
+    f'"p95_latency_ms": {p95_latency:.3f}, '
+    f'"drop_ratio": {drop_ratio:.6f}, '
+    f'"interval_jitter_ms": {interval_jitter:.3f}, '
+    f'"avg_interval_ms": {avg_gap:.3f}, '
+    f'"max_interval_ms": {max_gap:.3f}'
+    + '}'
+)
 node.destroy_node()
 rclpy.shutdown()
+PY
+)"
+
+read -r msg_count e2e_avg e2e_p95 drop_ratio gap_jitter_ms gap_max_ms <<< "$(python3 - <<PY
+import json
+stats = json.loads('''${stats_json}''')
+print(
+    f"{stats['count']} "
+    f"{stats['avg_latency_ms']:.3f} "
+    f"{stats['p95_latency_ms']:.3f} "
+    f"{stats['drop_ratio']:.4f} "
+    f"{stats['interval_jitter_ms']:.3f} "
+    f"{stats['max_interval_ms']:.3f}"
+)
 PY
 )"
 
@@ -109,6 +171,8 @@ PY
 
 echo "[stress_100hz] ${profile_line}"
 echo "[stress_100hz] msg_count=${msg_count} observed_hz=${obs_hz} target_hz=${PUBLISH_HZ} min_hz=${min_hz}"
+echo "[stress_100hz] e2e_latency_ms avg=${e2e_avg} p95=${e2e_p95} drop_ratio=${drop_ratio}"
+echo "[stress_100hz] interval_ms jitter=${gap_jitter_ms} max=${gap_max_ms}"
 echo "[stress_100hz] context_switch_hz=${ctxt_hz}"
 
 if [[ "${profile_line}" != *"status=PASS"* ]]; then
@@ -127,4 +191,17 @@ then
 else
   echo "[stress_100hz] FAIL: 输出频率低于目标下限，存在阻塞风险"
   exit 3
+fi
+
+if python3 - <<PY
+drop = float("${drop_ratio}")
+max_drop = 0.20
+import sys
+sys.exit(0 if drop <= max_drop else 1)
+PY
+then
+  echo "[stress_100hz] PASS: 掉包率 <= 0.20"
+else
+  echo "[stress_100hz] FAIL: 掉包率超过阈值(0.20)"
+  exit 4
 fi


### PR DESCRIPTION
## 变更说明
- 在 `scripts/stress_100hz.sh` 中新增指标统计：
  - `/swarm/state` 消息端到端时延（平均、P95）
  - 消息间隔抖动（jitter、max interval）
  - 掉包率（drop_ratio）
- 增加掉包率阈值验收：`drop_ratio <= 0.20`
- 在 `scripts/fire_mission_demo_check.sh` 中新增 mission 完成时延统计：`completion_s`
  - 从首次收到任务分配到 UAV 到达目标（阈值 8m）
- 同步更新 `docs/ros2-dev.md` 与 `docs/next-plan.md`

## 验收
- [x] 压测脚本输出并可复现端到端延迟与掉包指标
- [x] 100Hz 通过标准新增掉包率条件
- [x] 火场验收脚本输出任务完成时延字段 `completion_s`

Closes #7
