### PR TITLE
P1-1：任务规划算法升级（状态化评分与抗抖动）

### DIFF
--- a/scripts/mission_planner.py
+++ b/scripts/mission_planner.py
@@ -24,16 +24,33 @@ class MissionPlanner(Node):
         self.replan_hz: float = float(self.declare_parameter("replan_hz", 1.0).value)
         self.hotspot_per_uav: int = int(self.declare_parameter("hotspot_per_uav", 1).value)
         self.min_intensity: float = float(self.declare_parameter("min_intensity", 0.2).value)
+        self.revisit_bonus: float = float(self.declare_parameter("revisit_bonus", 0.25).value)
+        self.revisit_cycle_sec: float = float(self.declare_parameter("revisit_cycle_sec", 45.0).value)
+        self.hold_time_sec: float = float(self.declare_parameter("hold_time_sec", 4.0).value)
+        self.hold_distance_m: float = float(self.declare_parameter("hold_distance_m", 20.0).value)
+        self.hold_bonus: float = float(self.declare_parameter("hold_bonus", 0.35).value)
+        self.reassign_penalty: float = float(self.declare_parameter("reassign_penalty", 0.60).value)
+        self.distance_cost_scale: float = float(self.declare_parameter("distance_cost_scale", 0.0012).value)
+        self.coverage_min_distance_m: float = float(self.declare_parameter("coverage_min_distance_m", 90.0).value)
+        self.coverage_density_penalty: float = float(self.declare_parameter("coverage_density_penalty", 0.0006).value)
+        self.state_ttl_sec: float = float(self.declare_parameter("state_ttl_sec", 120.0).value)
 
         self.last_fire: Optional[FireState] = None
         self.last_swarm: Optional[SwarmState] = None
+        self._last_plan_stamp: Dict[str, float] = {}
+        self._last_plan_hotspot: Dict[str, str] = {}
+        self._last_plan_position: Dict[str, List[float]] = {}
+        self._hotspot_last_assigned_stamp: Dict[str, float] = {}
 
         self.sub_fire = self.create_subscription(FireState, self.fire_topic, self._on_fire, 10)
         self.sub_swarm = self.create_subscription(SwarmState, self.swarm_topic, self._on_swarm, 10)
         self.pub_plan = self.create_publisher(MissionPlan, self.plan_topic, 10)
         self.timer = self.create_timer(1.0 / max(0.1, self.replan_hz), self._tick)
         self.get_logger().info(
-            f"mission_planner started fire={self.fire_topic} swarm={self.swarm_topic} plan={self.plan_topic}"
+            "mission_planner started "
+            f"fire={self.fire_topic} "
+            f"swarm={self.swarm_topic} "
+            f"plan={self.plan_topic}"
         )
 
     def _on_fire(self, msg: FireState) -> None:
@@ -42,33 +59,98 @@ class MissionPlanner(Node):
     def _on_swarm(self, msg: SwarmState) -> None:
         self.last_swarm = msg
 
+    def _score_hotspot_target(self, now_sec: float, hs, uav) -> float:
+        dist = distance_score_m(list(uav.position), list(hs.position))
+        last_assigned = self._hotspot_last_assigned_stamp.get(hs.id)
+        if last_assigned is None:
+            revisit_ratio = 0.0
+        else:
+            revisit_ratio = min((now_sec - last_assigned) / max(self.revisit_cycle_sec, 1.0), 1.0)
+        base = float(hs.intensity) * (1.0 + self.revisit_bonus * revisit_ratio)
+        score = base - dist * self.distance_cost_scale
+
+        if uav.id in self._last_plan_hotspot:
+            last_hs = self._last_plan_hotspot[uav.id]
+            last_ts = self._last_plan_stamp.get(uav.id, now_sec)
+            if now_sec - last_ts <= self.hold_time_sec:
+                if last_hs == hs.id:
+                    score += self.hold_bonus
+                    last_pos = self._last_plan_position.get(uav.id, [])
+                    if len(last_pos) == 3 and distance_score_m(last_pos, list(uav.position)) <= self.hold_distance_m:
+                        score += self.hold_bonus
+                else:
+                    score -= self.reassign_penalty
+        return score
+
+    def _cover_penalty(self, candidate: Tuple[float, float, str], assigned_hotspots: List[Tuple[float, float, str]]) -> float:
+        if not assigned_hotspots:
+            return 0.0
+        min_dist = None
+        cand_lat = float(candidate[0])
+        cand_lon = float(candidate[1])
+        for lat, lon, _ in assigned_hotspots:
+            d = (((cand_lat - lat) * 111000.0) ** 2 + ((cand_lon - lon) * 111000.0) ** 2) ** 0.5
+            if min_dist is None or d < min_dist:
+                min_dist = d
+        if min_dist is None:
+            return 0.0
+        if min_dist >= self.coverage_min_distance_m:
+            return 0.0
+        return (self.coverage_min_distance_m - min_dist) * self.coverage_density_penalty
+
+    def _prune_memory(self, now_sec: float) -> None:
+        stale_uav = [uid for uid, ts in self._last_plan_stamp.items() if now_sec - ts > self.state_ttl_sec]
+        for uid in stale_uav:
+            self._last_plan_stamp.pop(uid, None)
+            self._last_plan_hotspot.pop(uid, None)
+            self._last_plan_position.pop(uid, None)
+        stale_hotspot = [hid for hid, ts in self._hotspot_last_assigned_stamp.items() if now_sec - ts > self.state_ttl_sec]
+        for hid in stale_hotspot:
+            self._hotspot_last_assigned_stamp.pop(hid, None)
+
     def _tick(self) -> None:
         if self.last_fire is None or self.last_swarm is None:
             return
+        now_sec = self.get_clock().now().nanoseconds / 1_000_000_000.0
         hotspots = [h for h in self.last_fire.hotspots if h.intensity >= self.min_intensity]
-        if not hotspots or not self.last_swarm.uavs:
+        uavs = self.last_swarm.uavs
+        if not hotspots or not uavs:
             return
-        hotspots.sort(key=lambda h: float(h.intensity), reverse=True)
-        uavs = list(self.last_swarm.uavs)
 
-        # Greedy assignment: each hotspot picks nearest unassigned UAV first.
-        used_uav: Set[str] = set()
-        assignments: Dict[str, Tuple[List[float], float, str]] = {}
+        self._prune_memory(now_sec)
+        if self.hotspot_per_uav <= 0:
+            return
+        max_assign = min(len(hotspots), len(uavs) * self.hotspot_per_uav)
+        if max_assign <= 0:
+            return
+
+        candidates: List[Tuple[float, str, str, List[float]]] = []
         for hs in hotspots:
-            best = None
-            for u in uavs:
-                if u.id in used_uav:
-                    continue
-                d = distance_score_m(list(u.position), list(hs.position))
-                if best is None or d < best[0]:
-                    best = (d, u.id)
-            if best is None:
-                continue
-            _, uid = best
-            used_uav.add(uid)
-            assignments[uid] = (list(hs.position), float(hs.intensity), f"track:{hs.id}")
-            if len(used_uav) >= max(1, self.hotspot_per_uav * len(hotspots)):
+            for uav in uavs:
+                score = self._score_hotspot_target(now_sec, hs, uav)
+                candidates.append((score, str(uav.id), hs.id, [float(hs.position[0]), float(hs.position[1]), float(hs.position[2])]))
+
+        candidates.sort(key=lambda item: item[0], reverse=True)
+
+        assignments: Dict[str, Tuple[List[float], float, str, str]] = {}
+        assigned_uav: Set[str] = set()
+        assigned_hotspots: List[Tuple[float, float, str]] = []
+        for raw_score, uid, hs_id, pos in candidates:
+            if len(assignments) >= max_assign:
                 break
+            if uid in assigned_uav:
+                continue
+            if any(existing_id == hs_id for _, _, existing_id in assigned_hotspots):
+                continue
+
+            penalty = self._cover_penalty((pos[0], pos[1], hs_id), assigned_hotspots)
+            final_score = raw_score - penalty
+            if final_score <= 0.0:
+                continue
+
+            assignments[uid] = (pos, final_score, hs_id, f"track:{hs_id}|score:{final_score:.2f}")
+            assigned_uav.add(uid)
+            assigned_hotspots.append((pos[0], pos[1], hs_id))
 
         if not assignments:
             return
@@ -76,15 +158,23 @@ class MissionPlanner(Node):
         out = MissionPlan()
         out.stamp = self.get_clock().now().to_msg()
         targets: List[MissionTarget] = []
-        for uid, (pos, pri, reason) in assignments.items():
+        assigned_position_by_uav: Dict[str, List[float]] = {}
+        for uid, (pos, pri, hs_id, reason) in assignments.items():
             t = MissionTarget()
             t.uav_id = uid
             t.position = [float(pos[0]), float(pos[1]), float(pos[2])]
             t.priority = float(pri)
             t.reason = reason
             targets.append(t)
+            assigned_position_by_uav[uid] = t.position
         out.targets = targets
         self.pub_plan.publish(out)
+
+        for uid, (_, _, hs_id, __) in assignments.items():
+            self._last_plan_stamp[uid] = now_sec
+            self._last_plan_hotspot[uid] = hs_id
+            self._last_plan_position[uid] = assigned_position_by_uav.get(uid, [0.0, 0.0, 0.0])
+            self._hotspot_last_assigned_stamp[hs_id] = now_sec
 
 
 def main() -> None:


### PR DESCRIPTION
## 变更说明
- 将 `scripts/mission_planner.py` 的原贪心最近邻策略升级为状态化评分分配。
- 新增去抖与连贯性策略：
  - 历史复访加权（revisit_bonus/revisit_cycle_sec）
  - 近邻保持惩罚（hold_time/hold_bonus/hold_distance）
  - 目标切换惩罚（reassign_penalty）
  - 覆盖分散约束（coverage_min_distance_m/coverage_density_penalty）
- 新增状态记忆字段：上次分配热点、时间与位置，用于任务稳定性控制。
- 支持更多可配置参数，保持 `MissionPlan` 接口与 `MissionTarget` 消息不变。

## 验收
- [x] 热点分配不再仅基于距离最近
- [x] 支持历史状态抑制抖动
- [x] 覆盖散布与任务切换行为有可配参数

Closes #5
