### PR TITLE
fix(swarm_interfaces): 补充 ament_cmake build_type 以修复 PX4 构建链 #24

### DIFF
--- a/ros2_ws/src/swarm_interfaces/package.xml
+++ b/ros2_ws/src/swarm_interfaces/package.xml
@@ -14,4 +14,8 @@
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>


### PR DESCRIPTION
## 变更摘要
- 在 `ros2_ws/src/swarm_interfaces/package.xml` 中补充：
  - `<export>`
  - `<build_type>ament_cmake</build_type>`
- 修复 PX4 联调中接口包构建类型识别异常问题。

## 关联 Issue
- Closes #24

## 风险评估
- 低风险：仅补充 package 元信息，不涉及接口定义与运行时逻辑。
- 主要风险在于构建系统兼容性差异；变更符合 ROS2 ament 包常规写法。

## 测试证据
- 本地 XML 结构校验通过：`xmllint --noout ros2_ws/src/swarm_interfaces/package.xml`
- 变更 diff 仅涉及 package.xml，新增 4 行 export/build_type 元信息。

## 回滚方案
- 若出现兼容性问题，回滚该 commit：`git revert e29fb9d`
- 或在 hotfix 分支撤销 export 区块并重新验证构建链。
