### PR TITLE
perf: 扩展 100Hz 压测指标与任务闭环观测

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@
 - 拓扑 profile（`avg_ms/max_ms/status`）
 - `/swarm/state` 实测频率（`observed_hz`）
 - 系统 context switch 频率（`context_switch_hz`）
+- 端到端延迟（`e2e_latency_ms avg/p95`）
+- 掉包率（`drop_ratio`）
+- 消息间隔抖动（`interval_ms jitter/max`）
+- 任务下发到 UAV 响应的闭环时延（`mission_loop_ms response`，当前为附加观测指标）
 
 ## Ricci/CUDA PoC 评估（#10）
 

--- a/docs/ros2-dev.md
+++ b/docs/ros2-dev.md
@@ -200,11 +200,13 @@ bash ./scripts/profile_topology_terrain_csv.sh 20 20 100 8 20
 说明：
 
 - 脚本会启动 manager + topology，并持续采集 `/swarm/state` 消息数。
-- 统计结果会输出：`observed_hz`、`context_switch_hz`、拓扑 `profile status`、`e2e_latency_ms(avg/p95)`、`drop_ratio`、`interval_ms(jitter/max)`。
+- 脚本会同时启动 `fire_adapter_demo.py` 与 `mission_planner.py`，用于观测任务下发到 UAV 响应的闭环时延。
+- 统计结果会输出：`observed_hz`、`context_switch_hz`、拓扑 `profile status`、`e2e_latency_ms(avg/p95)`、`drop_ratio`、`interval_ms(jitter/max)`、`mission_loop_ms(response)`、`mission_msgs`、`tracked_uav`。
 - 当前通过标准：
   - 拓扑 `status=PASS`
   - `observed_hz >= 0.8 * target_hz`
   - `drop_ratio <= 0.20`
+- `mission_loop_ms(response)` 当前作为附加观测指标输出；若未采集到，会输出 `WARN`，暂不作为强制失败条件。
 
 ## Fire Mission MVP（模拟 FDS 输出）
 

--- a/scripts/stress_100hz.sh
+++ b/scripts/stress_100hz.sh
@@ -19,7 +19,7 @@ export ROS_LOG_DIR=/tmp/roslog
 "${ROOT_DIR}/scripts/visual_demo_stop.sh" >/dev/null 2>&1 || true
 
 cleanup() {
-  kill "${TOPO_PID:-}" "${MANAGER_PID:-}" >/dev/null 2>&1 || true
+  kill "${PLANNER_PID:-}" "${FIRE_PID:-}" "${TOPO_PID:-}" "${MANAGER_PID:-}" >/dev/null 2>&1 || true
   "${ROOT_DIR}/scripts/visual_demo_stop.sh" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
@@ -29,8 +29,9 @@ ros2 run swarm_uav_manager swarm_uav_manager_node --ros-args \
   -p total_cores:="${TOTAL_CORES}" \
   -p publish_hz:="${PUBLISH_HZ}" \
   -p healthcheck_hz:=1 \
-  -p demo_motion:=true \
   -p output_topic:=/swarm/state_raw \
+  -p mission_follow_enabled:=true \
+  -p mission_topic:=/swarm/mission_targets \
   -p command_template:="sleep 1000" \
   > /tmp/swarm_manager_stress.log 2>&1 &
 MANAGER_PID=$!
@@ -45,15 +46,26 @@ ros2 run swarm_topology_analyzer swarm_topology_analyzer_node --ros-args \
   > /tmp/swarm_topology_stress.log 2>&1 &
 TOPO_PID=$!
 
+python3 "${ROOT_DIR}/scripts/fire_adapter_demo.py" \
+  --ros-args -p output_topic:=/env/fire_state -p publish_hz:=2.0 \
+  > /tmp/fire_adapter_stress.log 2>&1 &
+FIRE_PID=$!
+
+python3 "${ROOT_DIR}/scripts/mission_planner.py" \
+  --ros-args -p fire_topic:=/env/fire_state -p swarm_topic:=/swarm/state -p plan_topic:=/swarm/mission_targets \
+  > /tmp/mission_planner_stress.log 2>&1 &
+PLANNER_PID=$!
+
 sleep 1
 
 ctxt_before="$(awk '/^ctxt /{print $2}' /proc/stat)"
 
 stats_json="$(python3 - <<PY
+import math
 import time
 import rclpy
 from rclpy.node import Node
-from swarm_interfaces.msg import SwarmState
+from swarm_interfaces.msg import MissionPlan, SwarmState
 
 DURATION = float("${DURATION_SECONDS}")
 TOPIC = "/swarm/state"
@@ -63,12 +75,40 @@ class Counter(Node):
     def __init__(self) -> None:
         super().__init__("swarm_stress_counter")
         self.count = 0
+        self.mission_msgs = 0
         self.latencies_ms = []
         self.intervals_ms = []
         self.last_stamp_ns = None
+        self.latest_positions = {}
+        self.tracked_uav = None
+        self.tracked_baseline = None
+        self.assign_time_ns = None
+        self.mission_response_ms = None
         self.create_subscription(SwarmState, TOPIC, self.cb, 50)
+        self.create_subscription(MissionPlan, "/swarm/mission_targets", self.on_mission, 50)
+
+    def _distance_m(self, a, b) -> float:
+        dlat = (a[0] - b[0]) * 111000.0
+        dlon = (a[1] - b[1]) * 111000.0
+        dalt = a[2] - b[2]
+        return math.sqrt(dlat * dlat + dlon * dlon + dalt * dalt)
+
+    def on_mission(self, msg: MissionPlan) -> None:
+        self.mission_msgs += 1
+        if self.assign_time_ns is not None or not msg.targets:
+            return
+        target = msg.targets[0]
+        self.tracked_uav = target.uav_id
+        pos = self.latest_positions.get(self.tracked_uav)
+        if pos is None:
+            return
+        self.tracked_baseline = list(pos)
+        self.assign_time_ns = time.time_ns()
+
     def cb(self, msg: SwarmState) -> None:
         self.count += 1
+        for uav in msg.uavs:
+            self.latest_positions[uav.id] = list(uav.position)
         if not (msg.stamp.sec or msg.stamp.nanosec):
             return
         stamp_ns = msg.stamp.sec * 1_000_000_000 + msg.stamp.nanosec
@@ -80,12 +120,21 @@ class Counter(Node):
             if interval_ms > 0.0:
                 self.intervals_ms.append(interval_ms)
         self.last_stamp_ns = stamp_ns
+        if (
+            self.mission_response_ms is None and
+            self.tracked_uav is not None and
+            self.tracked_baseline is not None and
+            self.assign_time_ns is not None
+        ):
+            pos = self.latest_positions.get(self.tracked_uav)
+            if pos is not None and self._distance_m(self.tracked_baseline, pos) >= 5.0:
+                self.mission_response_ms = (time.time_ns() - self.assign_time_ns) / 1_000_000.0
 
 rclpy.init()
 node = Counter()
 end = time.time() + DURATION
 while time.time() < end:
-    rclpy.spin_once(node, timeout_sec=0.1)
+    rclpy.spin_once(node, timeout_sec=0.01)
 
 if node.count > 0 and node.latencies_ms:
     lat = sorted(node.latencies_ms)
@@ -111,13 +160,16 @@ drop_ratio = 0.0 if expected <= 0 else max(0.0, 1.0 - (node.count / float(expect
 print(
     '{'
     f'"count": {node.count}, '
+    f'"mission_msgs": {node.mission_msgs}, '
     f'"avg_latency_ms": {avg_latency:.3f}, '
     f'"p50_latency_ms": {p50_latency:.3f}, '
     f'"p95_latency_ms": {p95_latency:.3f}, '
     f'"drop_ratio": {drop_ratio:.6f}, '
     f'"interval_jitter_ms": {interval_jitter:.3f}, '
     f'"avg_interval_ms": {avg_gap:.3f}, '
-    f'"max_interval_ms": {max_gap:.3f}'
+    f'"max_interval_ms": {max_gap:.3f}, '
+    f'"mission_response_ms": {(-1.0 if node.mission_response_ms is None else node.mission_response_ms):.3f}, '
+    f'"tracked_uav": "{(node.tracked_uav or "")}"'
     + '}'
 )
 node.destroy_node()
@@ -125,16 +177,19 @@ rclpy.shutdown()
 PY
 )"
 
-read -r msg_count e2e_avg e2e_p95 drop_ratio gap_jitter_ms gap_max_ms <<< "$(python3 - <<PY
+read -r msg_count mission_msgs e2e_avg e2e_p95 drop_ratio gap_jitter_ms gap_max_ms mission_response_ms tracked_uav <<< "$(python3 - <<PY
 import json
 stats = json.loads('''${stats_json}''')
 print(
     f"{stats['count']} "
+    f"{stats['mission_msgs']} "
     f"{stats['avg_latency_ms']:.3f} "
     f"{stats['p95_latency_ms']:.3f} "
     f"{stats['drop_ratio']:.4f} "
     f"{stats['interval_jitter_ms']:.3f} "
-    f"{stats['max_interval_ms']:.3f}"
+    f"{stats['max_interval_ms']:.3f} "
+    f"{stats['mission_response_ms']:.3f} "
+    f"{stats['tracked_uav'] or 'na'}"
 )
 PY
 )"
@@ -173,6 +228,16 @@ echo "[stress_100hz] ${profile_line}"
 echo "[stress_100hz] msg_count=${msg_count} observed_hz=${obs_hz} target_hz=${PUBLISH_HZ} min_hz=${min_hz}"
 echo "[stress_100hz] e2e_latency_ms avg=${e2e_avg} p95=${e2e_p95} drop_ratio=${drop_ratio}"
 echo "[stress_100hz] interval_ms jitter=${gap_jitter_ms} max=${gap_max_ms}"
+if python3 - <<PY
+resp = float("${mission_response_ms}")
+import sys
+sys.exit(0 if resp >= 0.0 else 1)
+PY
+then
+  echo "[stress_100hz] mission_loop_ms response=${mission_response_ms} mission_msgs=${mission_msgs} tracked_uav=${tracked_uav}"
+else
+  echo "[stress_100hz] WARN: mission_loop_ms response=unavailable mission_msgs=${mission_msgs} tracked_uav=${tracked_uav}"
+fi
 echo "[stress_100hz] context_switch_hz=${ctxt_hz}"
 
 if [[ "${profile_line}" != *"status=PASS"* ]]; then


### PR DESCRIPTION
## 背景
- P0 的 stress_100hz.sh 已能输出拓扑帧耗时、实测频率和 context switch，但对于 P1 来说，仅靠这些指标不足以判断系统整体质量。
- #36 要求补齐更直接的系统级观测：端到端延迟、掉包率，以及任务下发到响应的闭环时延。

## 变更摘要
- 在 scripts/stress_100hz.sh 中保留现有拓扑 profile 输出兼容的前提下，新增 mission_loop_ms(response)、mission_msgs、tracked_uav 指标。
- 压测脚本会同步启动 fire_adapter_demo.py 与 mission_planner.py，用于观测任务下发到 UAV 首次明显响应的闭环时延。
- 将 /swarm/state 采样探针的 spin_once 间隔从 0.1s 调整到 0.01s，避免在 100Hz 场景下低估 observed_hz 与高估 drop_ratio。
- 在 docs/ros2-dev.md 与 README.md 中补充新增指标含义、输出格式和当前通过标准。
- mission_loop_ms 当前按附加观测指标输出，未纳入强制失败条件，符合先观测后收紧的策略。

## 影响范围
- scripts/stress_100hz.sh
- docs/ros2-dev.md
- README.md

## 测试证据
- ./scripts/stress_100hz.sh 20 20 100 6 20.0
  - 结果：
    - profile status=PASS
    - msg_count=506 observed_hz=84.33 target_hz=100 min_hz=80.00
    - e2e_latency_ms avg=2.338 p95=2.421 drop_ratio=0.1567
    - mission_loop_ms response=142.147 mission_msgs=5 tracked_uav=uav_17
  - 判定：PASS

## 风险评估
- 压测脚本额外启动 fire adapter 与 mission planner，会引入少量附加负载；但这是为了更真实地覆盖 P1 的任务闭环。
- mission_loop_ms 目前基于“首次任务下发到首次明显位移”的近似定义，后续如需更严格统计，可能需要更统一的时间戳来源。

## 回滚方案
- 若新增任务闭环观测在集成环境中不稳定，可仅保留现有 e2e/drop/profile 指标，回退本 PR。
- 或者保留脚本结构，只忽略 mission_loop_ms 行，将其继续作为非阻断诊断日志使用。

## 说明
- 本 PR 目标分支为 develop，由 feature 分支发起，符合当前 Git Flow 约束。